### PR TITLE
Update postw90_common.F90

### DIFF
--- a/src/postw90/postw90_common.F90
+++ b/src/postw90/postw90_common.F90
@@ -437,7 +437,8 @@ module w90_postw90_common
                                io_date,io_time,io_stopwatch
     use w90_parameters, only : num_wann,num_kpts,num_bands,have_disentangled,&
                                u_matrix_opt,u_matrix,m_matrix,&
-                               ndimwin,lwindow,nntot
+                               ndimwin,lwindow,nntot,&
+                               num_valence_bands,scissors_shift
 
     implicit none
 
@@ -472,23 +473,28 @@ module w90_postw90_common
              enddo
           enddo 
        endif
-       ! *** TODO *** Deallocate u_matrix_opt to save memory (on root)?
+       if (allocated(u_matrix_opt)) deallocate(u_matrix_opt)
+       if(.not.(num_valence_bands>0 .and. abs(scissors_shift)>1.0e-7_dp)) then
+          if (allocated(u_matrix)) deallocate(u_matrix)
+       endif
     endif
     call comms_bcast(v_matrix(1,1,1),num_bands*num_wann*num_kpts)
 
+    if(num_valence_bands>0 .and. abs(scissors_shift)>1.0e-7_dp) then
     if (.not.on_root .and. .not.allocated(u_matrix)) then
        allocate(u_matrix(num_wann,num_wann,num_kpts),stat=ierr)
        if (ierr/=0)&
             call io_error('Error allocating u_matrix in pw90common_wanint_data_dist')
     endif
     call comms_bcast(u_matrix(1,1,1),num_wann*num_wann*num_kpts)
-
-    if (.not.on_root .and. .not.allocated(m_matrix)) then
-       allocate(m_matrix(num_wann,num_wann,nntot,num_kpts),stat=ierr)
-       if (ierr/=0)&
-            call io_error('Error allocating m_matrix in pw90common_wanint_data_dist')
     endif
-    call comms_bcast(m_matrix(1,1,1,1),num_wann*num_wann*nntot*num_kpts)
+
+!    if (.not.on_root .and. .not.allocated(m_matrix)) then
+!       allocate(m_matrix(num_wann,num_wann,nntot,num_kpts),stat=ierr)
+!       if (ierr/=0)&
+!            call io_error('Error allocating m_matrix in pw90common_wanint_data_dist')
+!    endif
+!    call comms_bcast(m_matrix(1,1,1,1),num_wann*num_wann*nntot*num_kpts)
     
     call comms_bcast(have_disentangled,1)
 
@@ -498,12 +504,11 @@ module w90_postw90_common
           ! Do we really need these 'if not allocated'? Didn't use them for 
           ! eigval and kpt_latt above!
           
-          ! ***NOTE*** This should eventually be removed
-          if (.not.allocated(u_matrix_opt)) then
-             allocate(u_matrix_opt(num_bands,num_wann,num_kpts),stat=ierr)
-             if (ierr/=0)&
-              call io_error('Error allocating u_matrix_opt in pw90common_wanint_data_dist')
-          endif
+!          if (.not.allocated(u_matrix_opt)) then
+!             allocate(u_matrix_opt(num_bands,num_wann,num_kpts),stat=ierr)
+!             if (ierr/=0)&
+!              call io_error('Error allocating u_matrix_opt in pw90common_wanint_data_dist')
+!          endif
           
           if (.not.allocated(lwindow)) then
              allocate(lwindow(num_bands,num_kpts),stat=ierr)
@@ -519,7 +524,7 @@ module w90_postw90_common
      
        end if
 
-       call comms_bcast(u_matrix_opt(1,1,1),num_bands*num_wann*num_kpts)
+!       call comms_bcast(u_matrix_opt(1,1,1),num_bands*num_wann*num_kpts)
        call comms_bcast(lwindow(1,1),num_bands*num_kpts)
        call comms_bcast(ndimwin(1),num_kpts)
     end if


### PR DESCRIPTION
Currently, Wannier90 spends the useless memory in some parts, especially in the parallel run.
For this reason, when considering systems with large number of k points and bands, it might lead to memory error.

In addition to this, there are some points in which memory is used uselessly and they are also related to the parallelisation of both core parts (wannierization and disentanglement) and post-processing parts. 
Although I have my working parallel version of Wannier90, I will make an effort to apply, if any, the difference to the already-committed version.

H. Lee