### PR TITLE
Update get_oper.F90

### DIFF
--- a/src/postw90/get_oper.F90
+++ b/src/postw90/get_oper.F90
@@ -1201,7 +1201,7 @@ module w90_get_oper
     call utility_zgemmm(v_matrix(1:ns_a, 1:num_wann, ik_a),      'C', &
                         S_o(wm_a:wm_a+ns_a-1, wm_b:wm_b+ns_b-1), 'N', &
                         v_matrix(1:ns_b, 1:num_wann, ik_b),      'N', &
-                        S, eigval(:,ik_a), H)
+                        S, eigval(wm_a:wm_a+ns_a-1,ik_a), H)
   end subroutine get_gauge_overlap_matrix
 
 end module w90_get_oper


### PR DESCRIPTION
There seems to be a bug in the subroutine get_gauge_overlap_matrix in get_oper.F90.
Since the first dimension of eigval is num_bands,
in the argument of call utility_zgemmm
eigval(:,ik_a) should be eigval(wm_a:wm_a+ns_a-1,ik_a).

H. Lee