### PR TITLE
This fixes #123 (problem with geninterp with more processors than kpoints)

### DIFF
--- a/src/postw90/boltzwann.F90
+++ b/src/postw90/boltzwann.F90
@@ -232,13 +232,14 @@ contains
     call comms_array_split(TempNumPoints * MuNumPoints,counts,displs)
 
     ! I allocate the arrays for the spectra
-    allocate(LocalElCond(6,counts(my_node_id)),stat=ierr)
+    ! Allocate at least 1 entry
+    allocate(LocalElCond(6,max(1,counts(my_node_id))),stat=ierr)
     if (ierr/=0) call io_error('Error in allocating LocalElCond in boltzwann_main')
-    allocate(LocalSigmaS(6,counts(my_node_id)),stat=ierr)
+    allocate(LocalSigmaS(6,max(1,counts(my_node_id))),stat=ierr)
     if (ierr/=0) call io_error('Error in allocating LocalSigmaS in boltzwann_main')
-    allocate(LocalSeebeck(9,counts(my_node_id)),stat=ierr)
+    allocate(LocalSeebeck(9,max(1,counts(my_node_id))),stat=ierr)
     if (ierr/=0) call io_error('Error in allocating LocalSeebeck in boltzwann_main')
-    allocate(LocalKappa(6,counts(my_node_id)),stat=ierr)
+    allocate(LocalKappa(6,max(1,counts(my_node_id))),stat=ierr)
     if (ierr/=0) call io_error('Error in allocating LocalKappa in boltzwann_main')
     LocalElCond = 0._dp
     LocalSeebeck = 0._dp
@@ -462,10 +463,10 @@ contains
 
     ! The 6* factors are due to the fact that for each (T,mu) pair we have 6 components (xx,xy,yy,xz,yz,zz)
     ! NOTE THAT INSTEAD SEEBECK IS A FULL MATRIX AND HAS 9 COMPONENTS!
-    call comms_gatherv(LocalElCond(1,1),6*counts(my_node_id),ElCond(1,1,1),6*counts,6*displs)
-    call comms_gatherv(LocalSigmaS(1,1),6*counts(my_node_id),SigmaS(1,1,1),6*counts,6*displs)
-    call comms_gatherv(LocalSeebeck(1,1),9*counts(my_node_id),Seebeck(1,1,1),9*counts,9*displs)
-    call comms_gatherv(LocalKappa(1,1),6*counts(my_node_id),Kappa(1,1,1),6*counts,6*displs)
+    call comms_gatherv(LocalElCond,6*counts(my_node_id),ElCond,6*counts,6*displs)
+    call comms_gatherv(LocalSigmaS,6*counts(my_node_id),SigmaS,6*counts,6*displs)
+    call comms_gatherv(LocalSeebeck,9*counts(my_node_id),Seebeck,9*counts,9*displs)
+    call comms_gatherv(LocalKappa,6*counts(my_node_id),Kappa,6*counts,6*displs)
 
     if(on_root .and. (timing_level>0)) call io_stopwatch('boltzwann_main: calc_props',2)
 

--- a/src/postw90/comms.F90
+++ b/src/postw90/comms.F90
@@ -97,15 +97,23 @@ module w90_comms
 
   interface comms_gatherv
 !     module procedure comms_gatherv_int    ! to be done
-     module procedure comms_gatherv_real
-     module procedure comms_gatherv_cmplx
+     module procedure comms_gatherv_real_1
+     module procedure comms_gatherv_real_2
+     module procedure comms_gatherv_real_3
+     module procedure comms_gatherv_real_2_3
+     module procedure comms_gatherv_cmplx_1
+     module procedure comms_gatherv_cmplx_2
+     module procedure comms_gatherv_cmplx_3
+     module procedure comms_gatherv_cmplx_3_4
   end interface comms_gatherv
 
   interface comms_scatterv
      module procedure comms_scatterv_int_1  
      module procedure comms_scatterv_int_2
      module procedure comms_scatterv_int_3
-     module procedure comms_scatterv_real
+     module procedure comms_scatterv_real_1
+     module procedure comms_scatterv_real_2
+     module procedure comms_scatterv_real_3
 !     module procedure comms_scatterv_cmplx
   end interface comms_scatterv
 
@@ -812,20 +820,20 @@ contains
   end subroutine comms_allreduce_cmplx
 
 
-  subroutine comms_gatherv_real(array,localcount,rootglobalarray,counts,displs)
-    !! Gather real data to root node
+  subroutine comms_gatherv_real_1(array,localcount,rootglobalarray,counts,displs)
+    !! Gather real data to root node (for arrays of rank 1)
     implicit none
 
-    real(kind=dp), intent(inout)              :: array
+    real(kind=dp), dimension(:), intent(inout)   :: array
     !! local array for sending data
-    integer, intent(in)                       :: localcount
+    integer, intent(in)                          :: localcount
     !! localcount elements will be sent to the root node
-    real(kind=dp), intent(inout)              :: rootglobalarray
+    real(kind=dp), dimension(:), intent(inout)   :: rootglobalarray
     !! array on the root node to which data will be sent
-    integer, dimension(num_nodes), intent(in) :: counts
+    integer, dimension(num_nodes), intent(in)    :: counts
     !! how data should be partitioned, see MPI documentation or
     !! function comms_array_split
-    integer, dimension(num_nodes), intent(in) :: displs
+    integer, dimension(num_nodes), intent(in)    :: displs
 
 #ifdef MPI
     integer :: error
@@ -834,7 +842,7 @@ contains
          displs,MPI_double_precision,root_id,mpi_comm_world,error)
 
     if(error.ne.MPI_success) then
-       call io_error('Error in comms_gatherv_real')
+       call io_error('Error in comms_gatherv_real_1')
     end if
 
 #else
@@ -843,7 +851,106 @@ contains
 
     return
 
-  end subroutine comms_gatherv_real
+  end subroutine comms_gatherv_real_1
+
+  subroutine comms_gatherv_real_2(array,localcount,rootglobalarray,counts,displs)
+    !! Gather real data to root node (for arrays of rank 2)
+    implicit none
+
+    real(kind=dp), dimension(:,:), intent(inout) :: array
+    !! local array for sending data
+    integer, intent(in)                          :: localcount
+    !! localcount elements will be sent to the root node
+    real(kind=dp), dimension(:,:), intent(inout) :: rootglobalarray
+    !! array on the root node to which data will be sent
+    integer, dimension(num_nodes), intent(in)    :: counts
+    !! how data should be partitioned, see MPI documentation or
+    !! function comms_array_split
+    integer, dimension(num_nodes), intent(in)    :: displs
+
+#ifdef MPI
+    integer :: error
+
+    call MPI_gatherv(array,localcount,MPI_double_precision,rootglobalarray,counts,&
+         displs,MPI_double_precision,root_id,mpi_comm_world,error)
+
+    if(error.ne.MPI_success) then
+       call io_error('Error in comms_gatherv_real_2')
+    end if
+
+#else
+    call dcopy(localcount,array,1,rootglobalarray,1)
+#endif
+
+    return
+
+  end subroutine comms_gatherv_real_2
+
+  subroutine comms_gatherv_real_3(array,localcount,rootglobalarray,counts,displs)
+    !! Gather real data to root node (for arrays of rank 3)
+    implicit none
+
+    real(kind=dp), dimension(:,:,:), intent(inout) :: array
+    !! local array for sending data
+    integer, intent(in)                            :: localcount
+    !! localcount elements will be sent to the root node
+    real(kind=dp), dimension(:,:,:), intent(inout) :: rootglobalarray
+    !! array on the root node to which data will be sent
+    integer, dimension(num_nodes), intent(in)      :: counts
+    !! how data should be partitioned, see MPI documentation or
+    !! function comms_array_split
+    integer, dimension(num_nodes), intent(in)      :: displs
+
+#ifdef MPI
+    integer :: error
+
+    call MPI_gatherv(array,localcount,MPI_double_precision,rootglobalarray,counts,&
+         displs,MPI_double_precision,root_id,mpi_comm_world,error)
+
+    if(error.ne.MPI_success) then
+       call io_error('Error in comms_gatherv_real_3')
+    end if
+
+#else
+    call dcopy(localcount,array,1,rootglobalarray,1)
+#endif
+
+    return
+
+  end subroutine comms_gatherv_real_3
+
+  subroutine comms_gatherv_real_2_3(array,localcount,rootglobalarray,counts,displs)
+    !! Gather real data to root node (for arrays of rank 2 and 3, respectively)
+    implicit none
+
+    real(kind=dp), dimension(:,:), intent(inout) :: array
+    !! local array for sending data
+    integer, intent(in)                            :: localcount
+    !! localcount elements will be sent to the root node
+    real(kind=dp), dimension(:,:,:), intent(inout) :: rootglobalarray
+    !! array on the root node to which data will be sent
+    integer, dimension(num_nodes), intent(in)      :: counts
+    !! how data should be partitioned, see MPI documentation or
+    !! function comms_array_split
+    integer, dimension(num_nodes), intent(in)      :: displs
+
+#ifdef MPI
+    integer :: error
+
+    call MPI_gatherv(array,localcount,MPI_double_precision,rootglobalarray,counts,&
+         displs,MPI_double_precision,root_id,mpi_comm_world,error)
+
+    if(error.ne.MPI_success) then
+       call io_error('Error in comms_gatherv_real_2_3')
+    end if
+
+#else
+    call dcopy(localcount,array,1,rootglobalarray,1)
+#endif
+
+    return
+
+  end subroutine comms_gatherv_real_2_3
 
 
   ! Array: local array for sending data; localcount elements will be sent
@@ -851,15 +958,15 @@ contains
   ! rootglobalarray: array on the root node to which data will be sent
   ! counts, displs : how data should be partitioned, see MPI documentation or
   !                  function comms_array_split
-  subroutine comms_gatherv_cmplx(array,localcount,rootglobalarray,counts,displs)
-
+  subroutine comms_gatherv_cmplx_1(array,localcount,rootglobalarray,counts,displs)
+    !! Gather complex data to root node (for arrays of rank 1)
     implicit none
 
-    complex(kind=dp), intent(inout)           :: array
-    integer, intent(in)                       :: localcount
-    complex(kind=dp), intent(inout)           :: rootglobalarray
-    integer, dimension(num_nodes), intent(in) :: counts
-    integer, dimension(num_nodes), intent(in) :: displs
+    complex(kind=dp), dimension(:), intent(inout)     :: array
+    integer, intent(in)                               :: localcount
+    complex(kind=dp), dimension(:), intent(inout)     :: rootglobalarray
+    integer, dimension(num_nodes), intent(in)         :: counts
+    integer, dimension(num_nodes), intent(in)         :: displs
 
 #ifdef MPI
     integer :: error
@@ -868,7 +975,7 @@ contains
          displs,MPI_double_complex,root_id,mpi_comm_world,error)
 
     if(error.ne.MPI_success) then
-       call io_error('Error in comms_gatherv_cmplx')
+       call io_error('Error in comms_gatherv_cmplx_1')
     end if
 
 #else
@@ -877,8 +984,91 @@ contains
 
     return
 
-  end subroutine comms_gatherv_cmplx
+  end subroutine comms_gatherv_cmplx_1
 
+  subroutine comms_gatherv_cmplx_2(array,localcount,rootglobalarray,counts,displs)
+    !! Gather complex data to root node (for arrays of rank 2)
+    implicit none
+
+    complex(kind=dp), dimension(:,:), intent(inout)   :: array
+    integer, intent(in)                               :: localcount
+    complex(kind=dp), dimension(:,:), intent(inout)   :: rootglobalarray
+    integer, dimension(num_nodes), intent(in)         :: counts
+    integer, dimension(num_nodes), intent(in)         :: displs
+
+#ifdef MPI
+    integer :: error
+
+    call MPI_gatherv(array,localcount,MPI_double_complex,rootglobalarray,counts,&
+         displs,MPI_double_complex,root_id,mpi_comm_world,error)
+
+    if(error.ne.MPI_success) then
+       call io_error('Error in comms_gatherv_cmplx_2')
+    end if
+
+#else
+    call zcopy(localcount,array,1,rootglobalarray,1)
+#endif
+
+    return
+
+  end subroutine comms_gatherv_cmplx_2
+
+  subroutine comms_gatherv_cmplx_3(array,localcount,rootglobalarray,counts,displs)
+    !! Gather complex data to root node (for arrays of rank 3)
+    implicit none
+
+    complex(kind=dp), dimension(:,:,:), intent(inout) :: array
+    integer, intent(in)                               :: localcount
+    complex(kind=dp), dimension(:,:,:), intent(inout) :: rootglobalarray
+    integer, dimension(num_nodes), intent(in)         :: counts
+    integer, dimension(num_nodes), intent(in)         :: displs
+
+#ifdef MPI
+    integer :: error
+
+    call MPI_gatherv(array,localcount,MPI_double_complex,rootglobalarray,counts,&
+         displs,MPI_double_complex,root_id,mpi_comm_world,error)
+
+    if(error.ne.MPI_success) then
+       call io_error('Error in comms_gatherv_cmplx_3')
+    end if
+
+#else
+    call zcopy(localcount,array,1,rootglobalarray,1)
+#endif
+
+    return
+
+  end subroutine comms_gatherv_cmplx_3
+
+  subroutine comms_gatherv_cmplx_3_4(array,localcount,rootglobalarray,counts,displs)
+    !! Gather complex data to root node (for arrays of rank 3 and 4, respectively)
+    implicit none
+
+    complex(kind=dp), dimension(:,:,:), intent(inout)   :: array
+    integer, intent(in)                                 :: localcount
+    complex(kind=dp), dimension(:,:,:,:), intent(inout) :: rootglobalarray
+    integer, dimension(num_nodes), intent(in)           :: counts
+    integer, dimension(num_nodes), intent(in)           :: displs
+
+#ifdef MPI
+    integer :: error
+
+    call MPI_gatherv(array,localcount,MPI_double_complex,rootglobalarray,counts,&
+         displs,MPI_double_complex,root_id,mpi_comm_world,error)
+
+    if(error.ne.MPI_success) then
+       call io_error('Error in comms_gatherv_cmplx_3_4')
+    end if
+
+#else
+    call zcopy(localcount,array,1,rootglobalarray,1)
+#endif
+
+    return
+
+  end subroutine comms_gatherv_cmplx_3_4
 
   ! Array: local array for getting data; localcount elements will be fetched
   !        from the root node
@@ -886,30 +1076,28 @@ contains
   ! counts, displs : how data should be partitioned, see MPI documentation or
   !                  function comms_array_split
 
-  subroutine comms_scatterv_real(array,localcount,rootglobalarray,counts,displs)
-    !! Scatter data from root node
+  subroutine comms_scatterv_real_1(array,localcount,rootglobalarray,counts,displs)
+    !! Scatter real data from root node (array of rank 1)
     implicit none
 
-    real(kind=dp), intent(inout)              :: array
+    real(kind=dp), dimension(:), intent(inout) :: array
     !! local array for getting data
-    integer, intent(in)                       :: localcount
+    integer, intent(in)                        :: localcount
     !! localcount elements will be fetched from the root node
-    real(kind=dp), intent(inout)              :: rootglobalarray
+    real(kind=dp), dimension(:), intent(inout) :: rootglobalarray
     !! array on the root node from which data will be sent
-    integer, dimension(num_nodes), intent(in) :: counts
+    integer, dimension(num_nodes), intent(in)  :: counts
     !! how data should be partitioned, see MPI documentation or function comms_array_split
-    integer, dimension(num_nodes), intent(in) :: displs
+    integer, dimension(num_nodes), intent(in)  :: displs
 
 #ifdef MPI
     integer :: error
 
-!    call MPI_scatterv(array,localcount,MPI_double_precision,rootglobalarray,counts,&
-!         displs,MPI_double_precision,root_id,mpi_comm_world,error)
     call MPI_scatterv(rootglobalarray,counts,displs,MPI_double_precision,&
          array,localcount,MPI_double_precision,root_id,mpi_comm_world,error)
 
     if(error.ne.MPI_success) then
-       call io_error('Error in comms_scatterv_real')
+       call io_error('Error in comms_scatterv_real_1')
     end if
 
 #else
@@ -918,7 +1106,71 @@ contains
 
     return
 
-  end subroutine comms_scatterv_real
+  end subroutine comms_scatterv_real_1
+
+  subroutine comms_scatterv_real_2(array,localcount,rootglobalarray,counts,displs)
+    !! Scatter real data from root node (array of rank 2)
+    implicit none
+
+    real(kind=dp), dimension(:,:), intent(inout) :: array
+    !! local array for getting data
+    integer, intent(in)                          :: localcount
+    !! localcount elements will be fetched from the root node
+    real(kind=dp), dimension(:,:), intent(inout) :: rootglobalarray
+    !! array on the root node from which data will be sent
+    integer, dimension(num_nodes), intent(in)    :: counts
+    !! how data should be partitioned, see MPI documentation or function comms_array_split
+    integer, dimension(num_nodes), intent(in)    :: displs
+
+#ifdef MPI
+    integer :: error
+
+    call MPI_scatterv(rootglobalarray,counts,displs,MPI_double_precision,&
+         array,localcount,MPI_double_precision,root_id,mpi_comm_world,error)
+
+    if(error.ne.MPI_success) then
+       call io_error('Error in comms_scatterv_real_2')
+    end if
+
+#else
+    call dcopy(localcount,rootglobalarray,1,array,1)
+#endif
+
+    return
+
+  end subroutine comms_scatterv_real_2
+
+subroutine comms_scatterv_real_3(array,localcount,rootglobalarray,counts,displs)
+    !! Scatter real data from root node (array of rank 3)
+    implicit none
+
+    real(kind=dp), dimension(:,:,:), intent(inout) :: array
+    !! local array for getting data
+    integer, intent(in)                            :: localcount
+    !! localcount elements will be fetched from the root node
+    real(kind=dp), dimension(:,:,:), intent(inout) :: rootglobalarray
+    !! array on the root node from which data will be sent
+    integer, dimension(num_nodes), intent(in)      :: counts
+    !! how data should be partitioned, see MPI documentation or function comms_array_split
+    integer, dimension(num_nodes), intent(in)      :: displs
+
+#ifdef MPI
+    integer :: error
+
+    call MPI_scatterv(rootglobalarray,counts,displs,MPI_double_precision,&
+         array,localcount,MPI_double_precision,root_id,mpi_comm_world,error)
+
+    if(error.ne.MPI_success) then
+       call io_error('Error in comms_scatterv_real_3')
+    end if
+
+#else
+    call dcopy(localcount,rootglobalarray,1,array,1)
+#endif
+
+    return
+
+  end subroutine comms_scatterv_real_3
 
   subroutine comms_scatterv_int_1(array,localcount,rootglobalarray,counts,displs)
     !! Scatter integer data from root node (array of rank 1)
@@ -974,7 +1226,7 @@ contains
          Array,localcount,MPI_Integer,root_id,mpi_comm_world,error)
 
     if(error.ne.MPI_success) then
-       call io_error('Error in comms_scatterv_int_1')
+       call io_error('Error in comms_scatterv_int_2')
     end if
 
 #else
@@ -1017,8 +1269,6 @@ contains
     return
 
   end subroutine comms_scatterv_int_3
-
-
 
 end module w90_comms
 

--- a/test-suite/tests/jobconfig
+++ b/test-suite/tests/jobconfig
@@ -123,20 +123,12 @@ output = LaVO3.wout
 program = POSTW90_GENINTERPDAT_OK
 inputs_args = ('silicon.win', '')
 output = silicon_geninterp.dat
-# TODO: WE HAVE A BUG FOR GENINTERP IN PARALLEL, 
-# we run this test only in serial for now until when we fix issue
-# https://github.com/wannier-developers/wannier90/issues/123
-max_nprocs = 0
 
 # Test of disentanglement in spheres in k-space
 [testpostw90_si_geninterp_wsdistance/]
 program = POSTW90_GENINTERPDAT_OK
 inputs_args = ('silicon.win', '')
 output = silicon_geninterp.dat
-# TODO: WE HAVE A BUG FOR GENINTERP IN PARALLEL, 
-# we run this test only in serial for now until when we fix issue
-# https://github.com/wannier-developers/wannier90/issues/12
-max_nprocs = 0
 
 
 [categories]


### PR DESCRIPTION
Implemented various interfaces to scatterv and gatherv; but most importantly arrays are allocated (with minimal size) also on non-root nodes to avoid access to non-allocated areas.

Also, disabled tests are now reactivated.