### PR TITLE
bugfix for formatted uHu file read

### DIFF
--- a/src/parameters.F90
+++ b/src/parameters.F90
@@ -36,8 +36,7 @@ module w90_parameters
   !! Read the wvfn from fortran formatted file
   logical,           public, save :: spn_formatted
   !! Read the spin from fortran formatted file
-  logical                         :: uHu_formatted
-  logical,           public, save :: berry_uHu_formatted
+  logical,           public, save :: uHu_formatted
   !! Read the uHu from fortran formatted file
   integer,           public, save :: spin
   !! Spin up=1 down=2
@@ -548,9 +547,6 @@ contains
 
     uHu_formatted  =  .false.       ! formatted or "binary" file
     call param_get_keyword('uhu_formatted',found,l_value=uHu_formatted)
-
-    berry_uHu_formatted  =  uHu_formatted       ! formatted or "binary" file
-    call param_get_keyword('berry_uhu_formatted',found,l_value=berry_uHu_formatted)
 
     spin=1
     call param_get_keyword('spin',found,c_value=spin_str)
@@ -2617,7 +2613,7 @@ contains
        else
           write(stdout,'(1x,a46,7x,a11,13x,a1)') '|  Spn file-type                   :','unformatted','|'
        endif
-       if(berry_uHu_formatted) then
+       if(uHu_formatted) then
           write(stdout,'(1x,a46,9x,a9,13x,a1)')   '|  uHu file-type                   :','formatted','|'
        else
           write(stdout,'(1x,a46,7x,a11,13x,a1)') '|  uHu file-type                   :','unformatted','|'
@@ -5437,7 +5433,7 @@ contains
     call comms_bcast(length_unit,1) 
     call comms_bcast(wvfn_formatted,1) 
     call comms_bcast(spn_formatted,1) 
-    call comms_bcast(berry_uHu_formatted,1) 
+    call comms_bcast(uHu_formatted,1) 
     call comms_bcast(spin,1) 
     call comms_bcast(num_dump_cycles,1)
     call comms_bcast(num_print_cycles,1)

--- a/src/parameters.F90
+++ b/src/parameters.F90
@@ -36,6 +36,7 @@ module w90_parameters
   !! Read the wvfn from fortran formatted file
   logical,           public, save :: spn_formatted
   !! Read the spin from fortran formatted file
+  logical                         :: uHu_formatted
   logical,           public, save :: berry_uHu_formatted
   !! Read the uHu from fortran formatted file
   integer,           public, save :: spin
@@ -545,8 +546,11 @@ contains
     spn_formatted  =  .false.       ! formatted or "binary" file
     call param_get_keyword('spn_formatted',found,l_value=spn_formatted)
 
-    berry_uHu_formatted  =  .false.       ! formatted or "binary" file
-    call param_get_keyword('berry_uHu_formatted',found,l_value=berry_uHu_formatted)
+    uHu_formatted  =  .false.       ! formatted or "binary" file
+    call param_get_keyword('uhu_formatted',found,l_value=uHu_formatted)
+
+    berry_uHu_formatted  =  uHu_formatted       ! formatted or "binary" file
+    call param_get_keyword('berry_uhu_formatted',found,l_value=berry_uHu_formatted)
 
     spin=1
     call param_get_keyword('spin',found,c_value=spin_str)
@@ -2612,6 +2616,11 @@ contains
           write(stdout,'(1x,a46,9x,a9,13x,a1)')   '|  Spn file-type                   :','formatted','|'
        else
           write(stdout,'(1x,a46,7x,a11,13x,a1)') '|  Spn file-type                   :','unformatted','|'
+       endif
+       if(berry_uHu_formatted) then
+          write(stdout,'(1x,a46,9x,a9,13x,a1)')   '|  uHu file-type                   :','formatted','|'
+       else
+          write(stdout,'(1x,a46,7x,a11,13x,a1)') '|  uHu file-type                   :','unformatted','|'
        endif
     end if
 

--- a/src/postw90/get_oper.F90
+++ b/src/postw90/get_oper.F90
@@ -755,7 +755,7 @@ module w90_get_oper
                 if (berry_uHu_formatted) then
                    do m=1,num_bands
                       do n=1,num_bands
-                         read(uHu_in,'(2ES20.10)',err=106,end=106) c_real,c_img
+                         read(uHu_in,*,err=106,end=106) c_real,c_img
                          Ho_qb1_q_qb2(n,m) = cmplx(c_real,c_img,dp)
                       end do
                    end do

--- a/src/postw90/get_oper.F90
+++ b/src/postw90/get_oper.F90
@@ -669,7 +669,7 @@ module w90_get_oper
     use w90_parameters, only    : num_kpts,nntot,nnlist,num_wann,&
                                   num_bands,ndimwin,wb,bk,&
                                   have_disentangled,timing_level,&
-                                  scissors_shift,  berry_uHu_formatted
+                                  scissors_shift,  uHu_formatted
     use w90_postw90_common, only : nrpts,v_matrix
     use w90_io, only            : stdout,io_error,io_stopwatch,io_file_unit,&
                                   seedname
@@ -713,7 +713,7 @@ module w90_get_oper
        enddo
        
        uHu_in=io_file_unit()
-       if (berry_uHu_formatted) then
+       if (uHu_formatted) then
           open(unit=uHu_in, file=trim(seedname)//".uHu",form='formatted',&
                status='old',action='read',err=105)
           write(stdout,'(/a)',advance='no')&
@@ -752,7 +752,7 @@ module w90_get_oper
                 ! Read from .uHu file the matrices <u_{q+b1}|H_q|u_{q+b2}> 
                 ! between the original ab initio eigenstates
                 !
-                if (berry_uHu_formatted) then
+                if (uHu_formatted) then
                    do m=1,num_bands
                       do n=1,num_bands
                          read(uHu_in,*,err=106,end=106) c_real,c_img


### PR DESCRIPTION
I fixed bugs regarding reading of formatted uHu file.
also changed the name of the input keyword "berry_uHu_formatted" to "uHu_formatted",
to be consistent with the documentation and pw2wannier90.