### PR TITLE
fix python script generated by kslice

### DIFF
--- a/CHANGE.log
+++ b/CHANGE.log
@@ -4,8 +4,8 @@
 
 	The Maximally-Localised Generalised Wannier Functions Code
 
-* bug fix in kslice.F90 & example17 (missing type conversions when plotting Fermi 
-  lines in the python scripts)
+* bug fix in kslice.F90 & example17 (change to floor division in the python 
+  scripts for plotting Fermi lines), minor bug fix in example18 & tutorial
 
 v2.x.y (DATE)
 * G0W0 interface implemented (A. Marrazzo (EPFL, CH) and S. Tsirkin (DIPC, Spain)).

--- a/CHANGE.log
+++ b/CHANGE.log
@@ -4,6 +4,9 @@
 
 	The Maximally-Localised Generalised Wannier Functions Code
 
+* bug fix in kslice.F90 & example17 (missing type conversions when plotting Fermi 
+  lines in the python scripts)
+
 v2.x.y (DATE)
 * G0W0 interface implemented (A. Marrazzo (EPFL, CH) and S. Tsirkin (DIPC, Spain)).
   Added two utilities (gw2wannier90.py and k_mapper.py) and example 23 on

--- a/doc/tutorial/tutorial.tex
+++ b/doc/tutorial/tutorial.tex
@@ -2127,7 +2127,7 @@ Ref.~\cite{yao-prl04}, {\tt
 \begin{quote}
 myshell> gnuplot
 
-gnuplot> plot `Fe-kubo-A\_xy.dat' u 1:2 w l
+gnuplot> plot `Fe-kubo\_A\_xy.dat' u 1:2 w l
 \end{quote} }
 
 Comapare the $\omega\rightarrow 0$ limit with the result obtained
@@ -2147,7 +2147,7 @@ $10^{29}$~sec$^{-2}$. The needed conversion factor is $9\times
 \begin{quote}
 gnuplot> set yrange[-5:15]
 
-gnuplot> plot `Fe-kubo-A\_xy.dat' u 1:(\$1)*(\$3)*0.0137 w l
+gnuplot> plot `Fe-kubo\_A\_xy.dat' u 1:(\$1)*(\$3)*0.0137 w l
 \end{quote} }
 
 \subsection*{Further ideas}

--- a/examples/example17/iron_updn-kslice-fermi_lines.py
+++ b/examples/example17/iron_updn-kslice-fermi_lines.py
@@ -20,7 +20,7 @@ ef=   12.625600
  
 bands_up=np.loadtxt('iron_up-kslice-bands.dat')
 bands_dn=np.loadtxt('iron_dn-kslice-bands.dat')
-numbands=int(bands_up.size/num_pt)
+numbands=bands_up.size//num_pt
 bbands_up=bands_up.reshape((dimx,dimy,numbands))
 bbands_dn=bands_dn.reshape((dimx,dimy,numbands))
 for i in range(numbands):

--- a/examples/example17/iron_updn-kslice-fermi_lines.py
+++ b/examples/example17/iron_updn-kslice-fermi_lines.py
@@ -20,7 +20,7 @@ ef=   12.625600
  
 bands_up=np.loadtxt('iron_up-kslice-bands.dat')
 bands_dn=np.loadtxt('iron_dn-kslice-bands.dat')
-numbands=bands_up.size/num_pt
+numbands=int(bands_up.size/num_pt)
 bbands_up=bands_up.reshape((dimx,dimy,numbands))
 bbands_dn=bands_dn.reshape((dimx,dimy,numbands))
 for i in range(numbands):

--- a/examples/example18/Fe.win
+++ b/examples/example18/Fe.win
@@ -34,7 +34,7 @@ end kpoint_path
 
 #kslice = true
 #kslice_task = curv+fermi_lines
-#kslice_kmesh = 200
+#kslice_2dkmesh = 200
 #kslice_corner = 0.0  0.0  0.0
 #kslice_b1 =     0.5 -0.5 -0.5
 #kslice_b2 =     0.5  0.5  0.5

--- a/src/postw90/kslice.F90
+++ b/src/postw90/kslice.F90
@@ -668,7 +668,7 @@ subroutine script_fermi_lines(scriptunit)
   write(scriptunit,'(a)') " "
   write(scriptunit,'(a)')&
        "bands=np.loadtxt('"//trim(seedname)//"-kslice-bands.dat')"
-  write(scriptunit,'(a)') "numbands=bands.size/num_pt"
+  write(scriptunit,'(a)') "numbands=int(bands.size/num_pt)"
   write(scriptunit,'(a)') "if square:"
   write(scriptunit,'(a)')&
        "  bbands=bands.reshape((dimy,dimx,numbands))"

--- a/src/postw90/kslice.F90
+++ b/src/postw90/kslice.F90
@@ -668,7 +668,7 @@ subroutine script_fermi_lines(scriptunit)
   write(scriptunit,'(a)') " "
   write(scriptunit,'(a)')&
        "bands=np.loadtxt('"//trim(seedname)//"-kslice-bands.dat')"
-  write(scriptunit,'(a)') "numbands=int(bands.size/num_pt)"
+  write(scriptunit,'(a)') "numbands=bands.size//num_pt"
   write(scriptunit,'(a)') "if square:"
   write(scriptunit,'(a)')&
        "  bbands=bands.reshape((dimy,dimx,numbands))"


### PR DESCRIPTION
Hi, when I run examples17 in the tutorial, I came up with a python error:

```
Traceback (most recent call last):
  File "Fe-kslice-fermi_lines.py", line 36, in <module>
    bbands=bands.reshape((dimy,dimx,numbands))
TypeError: 'float' object cannot be interpreted as an integer
```

The python script was generated by kslice calculation of postw90.x.
I'm using Anaconda 4.3.30 on openSUSE Tumbleweed.

I found simply add an int() conversion could fix the bug. 
Thanks for the wannier90, it's wonderful!