### PR TITLE
Update berry.F90

### DIFF
--- a/src/postw90/berry.F90
+++ b/src/postw90/berry.F90
@@ -1100,6 +1100,8 @@ module w90_berry
              joint_level_spacing=sqrt(dot_product(vdum(:),vdum(:)))*Delta_k
              eta_smr=min(joint_level_spacing*kubo_adpt_smr_fac,&
                   kubo_adpt_smr_max)
+          else
+             eta_smr=kubo_smr_fixed_en_width
           endif
           rfac1=(occ(m)-occ(n))*(eig(m)-eig(n))
           occ_prod=occ(n)*(1.0_dp-occ(m))


### PR DESCRIPTION
Program was outputing NaN numbers in the SEEDNAME-jdos.dat, postw90 calculation with berry=true, berry_task=kubo, kubo_adpt_smr=false and finite value for kubo_smr_fixed_en_width. The subroutine berry_get_kubo_k did not give a value to variable eta_smr when kubo_adpt_smr was set to false. This made the lines 

arg=(eig(m)-eig(n)-real(omega,dp))/eta_smr

and

delta=utility_w0gauss(arg,kubo_smr_index)/eta_smr

problematic. The fixed line sets eta_smr=kubo_smr_fixed_en_width when kubo_adpt_smr=false.