### PR TITLE
Removed deallocate spn from compute_orb, causing crash at compilation…

### DIFF
--- a/pwscf/v6.2.1/pw2wannier90.f90
+++ b/pwscf/v6.2.1/pw2wannier90.f90
@@ -2892,7 +2892,6 @@ SUBROUTINE compute_orb
       DEALLOCATE(aux)
    ENDIF
    DEALLOCATE(evcq)
-   if(write_spn.and.noncolin) deallocate(spn)
 
    IF(any_uspp) THEN
       DEALLOCATE (  qb)


### PR DESCRIPTION
… time

(and actually not needed)