### PR TITLE
Avoid subtracting num_exclude_bands twice in library mode

### DIFF
--- a/src/parameters.F90
+++ b/src/parameters.F90
@@ -615,7 +615,11 @@ contains
        if(found) num_bands=i_temp
        if(.not.found) num_bands=num_wann
     end if
-    if (library) num_bands = num_bands - num_exclude_bands
+    ! RM_2018-03-21: this should only be done once, but param_read is called both in wannier_setup and wannier_run
+    ! RM_2018-03-21: commented line below, as now the correct value for
+    ! num_bands (already substracted) is set in library mode before calling
+    ! param_read
+!    if (library) num_bands = num_bands - num_exclude_bands
     if (.not. effective_model) then
        if(found .and. num_bands<num_wann) then
           call io_error('Error: num_bands must be greater than or equal to num_wann')

--- a/src/wannier_lib.F90
+++ b/src/wannier_lib.F90
@@ -134,11 +134,10 @@ subroutine wannier_setup(seed__name,mp_grid_loc,num_kpts_loc,&
   spinors=spinors_loc
 
   ! AAM_2016-09-14: initialise num_bands as it's used in param_read()
-  num_bands = num_bands_tot
+  ! RM_2018-03-21: num_exclude_bands is now subtracted below
+  num_bands = num_bands_tot - num_exclude_bands
   call param_read()
-  ! set num_bands and cell_volume as they are written to output in param_write
-  ! AAM_2016-09-14: num_exclude_bands is now subtracted in param_read
-  ! num_bands = num_bands_tot - num_exclude_bands
+  ! set cell_volume as it is written to output in param_write
   cell_volume = real_lattice(1,1)*(real_lattice(2,2)*real_lattice(3,3)-real_lattice(3,2)*real_lattice(2,3)) +&
                 real_lattice(1,2)*(real_lattice(2,3)*real_lattice(3,1)-real_lattice(3,3)*real_lattice(2,1)) +& 
                 real_lattice(1,3)*(real_lattice(2,1)*real_lattice(3,2)-real_lattice(3,1)*real_lattice(2,2))
@@ -168,7 +167,7 @@ subroutine wannier_setup(seed__name,mp_grid_loc,num_kpts_loc,&
   nntot_loc       = nntot        
   nnlist_loc(:,1:nntot)   =  nnlist(:,1:nntot)       
   nncell_loc(:,:,1:nntot) =  nncell(:,:,1:nntot)       
-  num_bands_loc=num_bands_tot-num_exclude_bands
+  num_bands_loc=num_bands
   num_wann_loc=num_wann
   if(allocated(proj_site)) then
      proj_site_loc(:,1:num_proj)   = proj_site(:,1:num_proj)    


### PR DESCRIPTION
Fixing the problem in library mode where num_exclude_bands was subtracted twice.
This was introduced in #19 trying to fix the fact `num_bands` wasn't defined in library mode.
The solution of #19 was to subtract num_exclude_bands in `param_read`, but `param_read` is run twice (in `wannier_setup` and `wannier_run`). Now, we set num_bands to the correct value (already subtracted) in `wannier_lib.f90`, but we do it before calling `param_read`, so this should be a fix both to the current problem and to the original problem of #19.
