### PR TITLE
Small fixes

### DIFF
--- a/README.install
+++ b/README.install
@@ -48,7 +48,7 @@
                    the user guide)
    make w90vdw     build the van der Waals code
    make w90pov     build the ray-tracing code
-   make test       run test cases
+   make tests      run test cases
    make doc        build the documentation
    make dist       make a tar-ball of the distribution
    make dist-lite  make a tar-ball of the src and tests only

--- a/test-suite/tests/testpostw90_example04_dos/.gitignore
+++ b/test-suite/tests/testpostw90_example04_dos/.gitignore
@@ -1,4 +1,3 @@
 *.wpout
 *.chk
-w90chk2chk.log 
-
+w90chk2chk.log

--- a/test-suite/tests/testpostw90_example04_pdos/.gitignore
+++ b/test-suite/tests/testpostw90_example04_pdos/.gitignore
@@ -1,4 +1,3 @@
 *.wpout
 *.chk
-w90chk2chk.log 
-
+w90chk2chk.log

--- a/test-suite/tests/testpostw90_fe_ahc/.gitignore
+++ b/test-suite/tests/testpostw90_fe_ahc/.gitignore
@@ -1,3 +1,3 @@
-*.wpout 
-*.chk 
+*.wpout
+*.chk
 w90chk2chk.log

--- a/test-suite/tests/testpostw90_fe_kpathcurv/.gitignore
+++ b/test-suite/tests/testpostw90_fe_kpathcurv/.gitignore
@@ -1,6 +1,6 @@
-*.wpout 
-*.chk 
-w90chk2chk.log 
+*.wpout
+*.chk
+w90chk2chk.log
 *.uHu
 *.dat
 *.py

--- a/test-suite/tests/testpostw90_fe_kpathmorbcurv/.gitignore
+++ b/test-suite/tests/testpostw90_fe_kpathmorbcurv/.gitignore
@@ -1,6 +1,6 @@
-*.wpout 
-*.chk 
-w90chk2chk.log 
+*.wpout
+*.chk
+w90chk2chk.log
 *.uHu
 *.dat
 *.py

--- a/test-suite/tests/testpostw90_fe_kslicecurv/.gitignore
+++ b/test-suite/tests/testpostw90_fe_kslicecurv/.gitignore
@@ -1,6 +1,6 @@
-*.wpout 
-*.chk 
-w90chk2chk.log 
+*.wpout
+*.chk
+w90chk2chk.log
 *.uHu
 *.dat
 *.py

--- a/test-suite/tests/testpostw90_fe_kslicemorb/.gitignore
+++ b/test-suite/tests/testpostw90_fe_kslicemorb/.gitignore
@@ -1,6 +1,6 @@
-*.wpout 
-*.chk 
-w90chk2chk.log 
+*.wpout
+*.chk
+w90chk2chk.log
 *.uHu
 *.dat
 *.py

--- a/test-suite/tests/testpostw90_fe_kubo_Axy/.gitignore
+++ b/test-suite/tests/testpostw90_fe_kubo_Axy/.gitignore
@@ -1,6 +1,6 @@
-*.wpout 
-*.chk 
-w90chk2chk.log 
+*.wpout
+*.chk
+w90chk2chk.log
 *.uHu
 *.dat
 *.py

--- a/test-suite/tests/testpostw90_fe_kubo_Szz/.gitignore
+++ b/test-suite/tests/testpostw90_fe_kubo_Szz/.gitignore
@@ -1,6 +1,6 @@
-*.wpout 
-*.chk 
-w90chk2chk.log 
+*.wpout
+*.chk
+w90chk2chk.log
 *.uHu
 *.dat
 *.py

--- a/test-suite/tests/testpostw90_fe_kubo_jdos/.gitignore
+++ b/test-suite/tests/testpostw90_fe_kubo_jdos/.gitignore
@@ -1,6 +1,6 @@
-*.wpout 
-*.chk 
-w90chk2chk.log 
+*.wpout
+*.chk
+w90chk2chk.log
 *.uHu
 *.dat
 *.py

--- a/test-suite/tests/testpostw90_fe_morb/.gitignore
+++ b/test-suite/tests/testpostw90_fe_morb/.gitignore
@@ -1,4 +1,4 @@
-*.wpout 
-*.chk 
-w90chk2chk.log 
+*.wpout
+*.chk
+w90chk2chk.log
 *.uHu

--- a/test-suite/tests/testpostw90_fe_morbandahc/.gitignore
+++ b/test-suite/tests/testpostw90_fe_morbandahc/.gitignore
@@ -1,4 +1,4 @@
-*.wpout 
-*.chk 
-w90chk2chk.log 
+*.wpout
+*.chk
+w90chk2chk.log
 *.uHu

--- a/test-suite/tests/testpostw90_fe_spin/.gitignore
+++ b/test-suite/tests/testpostw90_fe_spin/.gitignore
@@ -1,4 +1,4 @@
-*.wpout 
-*.chk 
-w90chk2chk.log 
+*.wpout
+*.chk
+w90chk2chk.log
 *.uHu

--- a/test-suite/tests/testpostw90_te_gyrotropic/.gitignore
+++ b/test-suite/tests/testpostw90_te_gyrotropic/.gitignore
@@ -1,5 +1,5 @@
-*.wpout 
-*.chk 
-w90chk2chk.log 
+*.wpout
+*.chk
+w90chk2chk.log
 *.uHu
 *.dat

--- a/test-suite/tests/testpostw90_te_gyrotropic_C/.gitignore
+++ b/test-suite/tests/testpostw90_te_gyrotropic_C/.gitignore
@@ -1,5 +1,5 @@
-*.wpout 
-*.chk 
-w90chk2chk.log 
+*.wpout
+*.chk
+w90chk2chk.log
 *.uHu
 *.dat

--- a/test-suite/tests/testpostw90_te_gyrotropic_D0/.gitignore
+++ b/test-suite/tests/testpostw90_te_gyrotropic_D0/.gitignore
@@ -1,5 +1,5 @@
-*.wpout 
-*.chk 
-w90chk2chk.log 
+*.wpout
+*.chk
+w90chk2chk.log
 *.uHu
 *.dat

--- a/test-suite/tests/testpostw90_te_gyrotropic_Dw/.gitignore
+++ b/test-suite/tests/testpostw90_te_gyrotropic_Dw/.gitignore
@@ -1,5 +1,5 @@
-*.wpout 
-*.chk 
-w90chk2chk.log 
+*.wpout
+*.chk
+w90chk2chk.log
 *.uHu
 *.dat

--- a/test-suite/tests/testpostw90_te_gyrotropic_K/.gitignore
+++ b/test-suite/tests/testpostw90_te_gyrotropic_K/.gitignore
@@ -1,5 +1,5 @@
-*.wpout 
-*.chk 
-w90chk2chk.log 
+*.wpout
+*.chk
+w90chk2chk.log
 *.uHu
 *.dat

--- a/test-suite/tests/testpostw90_te_gyrotropic_NOA/.gitignore
+++ b/test-suite/tests/testpostw90_te_gyrotropic_NOA/.gitignore
@@ -1,5 +1,5 @@
-*.wpout 
-*.chk 
-w90chk2chk.log 
+*.wpout
+*.chk
+w90chk2chk.log
 *.uHu
 *.dat

--- a/test-suite/tests/testpostw90_te_gyrotropic_dos/.gitignore
+++ b/test-suite/tests/testpostw90_te_gyrotropic_dos/.gitignore
@@ -1,5 +1,5 @@
-*.wpout 
-*.chk 
-w90chk2chk.log 
+*.wpout
+*.chk
+w90chk2chk.log
 *.uHu
 *.dat


### PR DESCRIPTION
The first commit makes a small fix to README.install to reflect the change (#156) in the make target for running the tests.

The second commit removes trailing whitespace in the gitignore files throughout the repository. Trailing whitespace in the gitignore files was causing some files produced during testing not be ignored.

This brings up the question of how to deal with whitespace. It is common practice to exclude trailing whitespace, usually by configuring the text editor to trim whitespace upon saving. Perhaps it is desirable to trim trailing whitespace throughout the codebase and implement whitespace checking as part of accepting a pull request.