### PR TITLE
Making sure the distribution tar.gz is slim

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
 test-suite/* linguist-vendored
+# Add here files that should not be added to the distribution 
+# (via git archive)
+/test-suite export-ignore
+.gitignore export-ignore
+/examples/example24/wan_files export-ignore

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ dist:
 	# For now hardcoded to 3.0.0, and using HEAD
 	# Better to get the version from the io.F90 file and use
 	# the tag (e.g. v3.0.0) instead of HEAD
-	cd $(ROOTDIR) && git archive HEAD -o wannier90-3.0.0.tar.gz
+	cd $(ROOTDIR) && git archive HEAD --prefix=wannier90-3.0.0/ -o wannier90-3.0.0.tar.gz
 
 dist-legacy:
 	@(cd $(ROOTDIR) && $(TAR) -cz --transform='s,^\./,wannier90-3.0/,' -f wannier90-3.0.tar.gz \


### PR DESCRIPTION
In particular, avoiding to include the test-suite folder
that is quite big. 

Fixes #243 