### PR TITLE
Do not print errors when cleaning outside of a git dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,10 +167,10 @@ dist-legacy:
 		./CHANGE.log \
 	)
 
-test-serial: 
+test-serial: w90chk2chk wannier post  
 	(cd $(ROOTDIR)/test-suite && ./run_tests --category=default )
 
-test-parallel:
+test-parallel: w90chk2chk wannier post 
 	(cd $(ROOTDIR)/test-suite && ./run_tests --category=default --numprocs=4 )
 
 # Alias

--- a/test-suite/clean_tests
+++ b/test-suite/clean_tests
@@ -69,6 +69,10 @@ if __name__ == "__main__":
                         help='Remove also files that are ignored by git (otherwise, just warn about their presence')
     args = parser.parse_args()
 
+    is_git_repo = True
+    errcode = subprocess.call(['git', '-C', test_folder, 'rev-parse', '--git-dir'])
+    if errcode != 0:
+        is_git_repo = False
 
     valid_categories = get_valid_categories()
     for testname in os.listdir(test_folder):
@@ -110,10 +114,11 @@ if __name__ == "__main__":
                 # Only consider files (anyway folders cannot be
                 # ignored in git)
                 continue
-            errcode = subprocess.call(['git', 'check-ignore', "-q", entryfname])
-            if errcode == 0:
-                # It is ignored
-                entries_gitignored.append(fname)
+            if is_git_repo:
+                errcode = subprocess.call(['git', 'check-ignore', "-q", entryfname])
+                if errcode == 0:
+                    # It is ignored
+                    entries_gitignored.append(fname)
 
         for entry in entries_to_delete:
             print("    Deleting {}...".format(entry))
@@ -135,6 +140,9 @@ if __name__ == "__main__":
             else:
                 print("    ** Potentially deletable (use -i option to delete): {}".format(entry))
 
+    if not is_git_repo:
+        print("*** Warning! I am not able to fully clean the test directories ***")
+        print("*** as this is not a git repository                            ***")
 
 
 


### PR DESCRIPTION
'make clean' for the test dir relies on being in a git directory.
For now we just check if we are in a git directory and ignore/warn
if this is not the case.

Now it prints at the bottom:
```
*** Warning! I am not able to fully clean the test directories ***
*** as this is not a git repository                            ***
```

This fixes #246 