### PR TITLE
Not including anymore the xsf.gz examples of w90pov

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@ test-suite/* linguist-vendored
 # Add here files that should not be added to the distribution 
 # (via git archive)
 .gitignore export-ignore
+/utility/w90pov/**/*.xsf.gz export-ignore

--- a/utility/w90pov/examples/1.PdN2_1/pdn2_00004.xsf.gz.txt
+++ b/utility/w90pov/examples/1.PdN2_1/pdn2_00004.xsf.gz.txt
@@ -1,0 +1,3 @@
+The example file pdn2_00004.xsf.gz is not part of the packaged distribution of Wannier90 but can be found online on the GitHub repository, at the address:
+
+https://github.com/wannier-developers/wannier90/raw/v2.1/utility/w90pov/examples/1.PdN2_1/pdn2_00004.xsf.gz

--- a/utility/w90pov/examples/1.PdN2_1/pdn2_00006.xsf.gz.txt
+++ b/utility/w90pov/examples/1.PdN2_1/pdn2_00006.xsf.gz.txt
@@ -1,0 +1,3 @@
+The example file pdn2_00006.xsf.gz is not part of the packaged distribution of Wannier90 but can be found online on the GitHub repository, at the address:
+
+https://github.com/wannier-developers/wannier90/raw/v2.1/utility/w90pov/examples/1.PdN2_1/pdn2_00006.xsf.gz

--- a/utility/w90pov/examples/1.PdN2_1/pdn2_00012.xsf.gz.txt
+++ b/utility/w90pov/examples/1.PdN2_1/pdn2_00012.xsf.gz.txt
@@ -1,0 +1,3 @@
+The example file pdn2_00012.xsf.gz is not part of the packaged distribution of Wannier90 but can be found online on the GitHub repository, at the address:
+
+https://github.com/wannier-developers/wannier90/raw/v2.1/utility/w90pov/examples/1.PdN2_1/pdn2_00012.xsf.gz

--- a/utility/w90pov/examples/1.PdN2_1/pdn2_00018.xsf.gz.txt
+++ b/utility/w90pov/examples/1.PdN2_1/pdn2_00018.xsf.gz.txt
@@ -1,0 +1,3 @@
+The example file pdn2_00018.xsf.gz is not part of the packaged distribution of Wannier90 but can be found online on the GitHub repository, at the address:
+
+https://github.com/wannier-developers/wannier90/raw/v2.1/utility/w90pov/examples/1.PdN2_1/pdn2_00018.xsf.gz

--- a/utility/w90pov/examples/4.LaBr3_1/labr3_00001.xsf.gz.txt
+++ b/utility/w90pov/examples/4.LaBr3_1/labr3_00001.xsf.gz.txt
@@ -1,0 +1,3 @@
+The example file labr3_00001.xsf.gz is not part of the packaged distribution of Wannier90 but can be found online on the GitHub repository, at the address:
+
+https://github.com/wannier-developers/wannier90/raw/v2.1/utility/w90pov/examples/4.LaBr3_1/labr3_00001.xsf.gz

--- a/utility/w90pov/examples/5.LaBr3_2/labr3_00004.xsf.gz.txt
+++ b/utility/w90pov/examples/5.LaBr3_2/labr3_00004.xsf.gz.txt
@@ -1,0 +1,3 @@
+The example file labr3_00004.xsf.gz is not part of the packaged distribution of Wannier90 but can be found online on the GitHub repository, at the address:
+
+https://github.com/wannier-developers/wannier90/raw/v2.1/utility/w90pov/examples/5.LaBr3_2/labr3_00004.xsf.gz


### PR DESCRIPTION
These remain in the git repo but are not included anymore in the distribution.
They are instead replaced with a link to the github file