### PR TITLE
Fix a bug and add a check in parameters.f90

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Moreover, it generates a new file `seedname_band.labelinfo.dat` with information
 
 - Improvements to the Wigner-Seitz detection routines [[#117]](https://github.com/wannier-developers/wannier90/pull/117) [[#109]](https://github.com/wannier-developers/wannier90/pull/109)
 
+- Fix berry_task check for morb, and add check for kpoint_path block in parameters
 
 
 

--- a/src/parameters.F90
+++ b/src/parameters.F90
@@ -1312,6 +1312,8 @@ contains
         index(kpath_task, 'curv') == 0 .and. &
         index(kpath_task, 'morb') == 0) call io_error &
       ('Error: value of kpath_task not recognised in param_read')
+    if (bands_num_spec_points == 0 .and. kpath) &
+      call io_error('Error: a kpath plot has been requested but there is no kpoint_path block')
 
     kpath_num_points = 100
     call param_get_keyword('kpath_num_points', found, &

--- a/src/parameters.F90
+++ b/src/parameters.F90
@@ -3160,7 +3160,7 @@ contains
       else
         write (stdout, '(1x,a46,10x,a8,13x,a1)') '|  Compute Shift Current                     :', '       F', '|'
       endif
-      if (index(berry_task, 'kubo') > 0) then
+      if (index(berry_task, 'morb') > 0) then
         write (stdout, '(1x,a46,10x,a8,13x,a1)') '|  Compute Orbital Magnetisation             :', '       T', '|'
       else
         write (stdout, '(1x,a46,10x,a8,13x,a1)') '|  Compute Orbital Magnetisation             :', '       F', '|'


### PR DESCRIPTION
1. It seems that the `berry_task` check for `morb` is wrong in `parameters.f90`, while in the previous version of `wannier90` this was correct. 

2. I have added a check for `kpoint_path` block since I accidentally encountered a segmentation fault when plotting kpath. The situation is that if `kpath = true` while there is no `begin kpoint_path ... end kpoint_path` block in the input file, the `postw90.x` will complain: 

        Program received signal SIGSEGV: Segmentation fault - invalid memory reference.

        Backtrace for this error:
        #0  0x7f63e4604dff in ???
        #1  0x55cc0cdecdd0 in ???
        #2  0x55cc0cd444af in ???
        #3  0x55cc0cd44871 in ???
        #4  0x7f63e45f1222 in ???
        #5  0x55cc0cd4349d in ???
        #6  0xffffffffffffffff in ???
        [1]    14953 segmentation fault (core dumped)  ../../postw90.x Fe

    compiled with gfortran 8.2.1 on Linux.

3. I recently implented a new feature of calculating spin Hall conductivity based on wannier90 (https://journals.aps.org/prb/abstract/10.1103/PhysRevB.98.214402). I would like to share my code with the community. If it could be merged into wannier90, I would like to write the corresponding documentaion and tutorials and create a pull request in the next few weeks! 
