### PR TITLE
[bug fix] Extension maximum length of file_name in kpath and kslice in postw90

### DIFF
--- a/src/postw90/kpath.F90
+++ b/src/postw90/kpath.F90
@@ -66,7 +66,7 @@ contains
                          range
     real(kind=dp), allocatable, dimension(:) :: kpath_len
     logical           :: plot_bands, plot_curv, plot_morb
-    character(len=40) :: file_name
+    character(len=120) :: file_name
 
     complex(kind=dp), allocatable :: HH(:, :)
     complex(kind=dp), allocatable :: UU(:, :)

--- a/src/postw90/kpath.F90
+++ b/src/postw90/kpath.F90
@@ -66,7 +66,7 @@ contains
                          range
     real(kind=dp), allocatable, dimension(:) :: kpath_len
     logical           :: plot_bands, plot_curv, plot_morb
-    character(len=20) :: file_name
+    character(len=40) :: file_name
 
     complex(kind=dp), allocatable :: HH(:, :)
     complex(kind=dp), allocatable :: UU(:, :)

--- a/src/postw90/kslice.F90
+++ b/src/postw90/kslice.F90
@@ -71,7 +71,7 @@ contains
                          zhat(3), vdum(3), rdum
     logical           :: plot_fermi_lines, plot_curv, plot_morb, &
                          fermi_lines_color, heatmap
-    character(len=40) :: filename, square
+    character(len=120) :: filename, square
 
     integer, allocatable :: bnddataunit(:)
     complex(kind=dp), allocatable :: HH(:, :)


### PR DESCRIPTION
I solved a small problem with postw90. Maximum length of output file name (eg, python script for plotting) is too small. In the current kpath.F90, only 20 characters can be used as a file name including a suffix (eg "-bands + curv_z.py"). It causes trouble when one tries to make seed name longer than 5 like BaTiO3.

I thank all of wannier90 developers.