### PR TITLE
Gathering matrices before dumping chk file

### DIFF
--- a/src/parameters.F90
+++ b/src/parameters.F90
@@ -3760,6 +3760,9 @@ contains
     !! Write checkpoint file
     !! IMPORTANT! If you change the chkpt format, adapt
     !! accordingly also the w90chk2chk.x utility!
+    !! Also, note that this routine writes the u_matrix and the m_matrix - in parallel
+    !! mode these are however stored in distributed form in, e.g., u_matrix_loc only, so
+    !! if you are changing the u_matrix, remember to gather it from u_matrix_loc first!
     !=================================================!
 
     use w90_io, only: io_file_unit, io_date, seedname


### PR DESCRIPTION
Fixes #278

In the parallel code, the `u_matrix` is distributed
in `u_matrix_loc`. However, the `write_chkpt` routine
writes on file the content of the `u_matrix` that was not
updated during the wannierisation but only at the end.
Therefore, the code was always restarting from the results
of the disentanglement (unless it was stop appropriately
with a fixed number of steps).

Now we gather the `u_matrix_loc` and `m_matrix_loc` just
before dumping, in the `wannierise.F90` file.
Note that gathering is not needed in the main program file
because the dumping of the .chk file there happens right
after the disentanglement, where the u_matrix is still not
scattered.

Also, I'm not 100% sure that also the `m_matrix_loc` needs to be
gathered, but anyway this is what is done at the end of the
cycle in `wann_main` so it shouldn't harm (at worst it can be
a bit less efficient).

Final note: this is very hard to test automatically, so I
couldn't do a proper testing of this PR.