### PR TITLE
Fix a missing allocation in kslice

### DIFF
--- a/src/postw90/kslice.F90
+++ b/src/postw90/kslice.F90
@@ -344,6 +344,7 @@ contains
 
         ! For gnuplot, using 'grid data' format
         if (.not. heatmap) then
+          if (.not. allocated(bnddataunit)) allocate (bnddataunit(num_wann))
           do n = 1, num_wann
             n1 = n/100
             n2 = (n - n1*100)/10


### PR DESCRIPTION
This was leading to a segfault as reported by Frank Freimuth

This commit replaces PR #284 that had tests failing (because of the pre-commit hooks)