### PR TITLE
added writing ??_R files for wannier-berri

### DIFF
--- a/doc/tutorial/Makefile
+++ b/doc/tutorial/Makefile
@@ -1,4 +1,4 @@
-tutorial.pdf: tutorial.tex
+tutorial.pdf: tutorial.tex ../wannier90.bib
 	pdflatex tutorial.tex 
 	bibtex tutorial
 	pdflatex tutorial.tex

--- a/doc/user_guide/Makefile
+++ b/doc/user_guide/Makefile
@@ -1,6 +1,6 @@
 TEXFILES=$(wildcard *.tex)
 
-user_guide.pdf: $(TEXFILES)
+user_guide.pdf: $(TEXFILES) ../wannier90.bib
 	pdflatex user_guide 
 	bibtex user_guide
 	pdflatex user_guide

--- a/doc/user_guide/postw90params.tex
+++ b/doc/user_guide/postw90params.tex
@@ -154,6 +154,8 @@ magnetic moment per cell\\
 {\sc spn\_formatted}  & L & 
   Read a formatted {\tt seedname.spn} file\\
   {\sc berry\_curv\_unit} & S & Unit of Berry curvature\\ 
+  {\sc get\_oper\_save} & L & save the {\tt HH\_R, AA\_R, SS\_R}, etc arrays to files to be read by {\tt  wannier-berri} code\\
+  {\sc get\_oper\_save\_task} & S & files to be saved \\
  \hline
 \end{tabular}
 \caption[Parameter file keywords controlling \postw.]  {{\tt
@@ -705,6 +707,69 @@ beyond which the delta functions are taken as zero.
 
 The default value is 5.0. 
 
+\subsection{\tt logical :: get\_oper\_save}
+
+If {\tt get\_oper\_save=true}, the real-space matrix elements {\tt HH\_R, AA\_R, SS\_R},  
+and others evaluated in the {\tt get\_oper} module, are saved to files, that can be read by the {\tt wannier-berri} code\cite{wannier-berri}
+
+First, the file {\tt seedname\_R.info} is written (formatted), which contains 
+\begin{itemize}
+\item the number of wannier functions, number of real-space $\RR$-vectors, and wether the wavefunctions are spinors.
+\item real-space unit cell vectors
+\item real-space $\RR$-vectors and their degeneracies
+\item if {\tt use\_ws\_distance=true}, also the information needed for the minimal-distance replica selection is written
+\end{itemize}
+Then, the {\tt seedname\_HH\_R} file is written (unformatted), 
+containing the Hamiltonian matrix elements $\langle 0n | H | \RR m \rangle$.
+If the parameter {\tt get\_oper\_save\_task} is set, additional files are written (see below)
+
+The default value is {\tt false}.
+
+\subsection{\tt character(len=20) :: get\_oper\_save\_task}
+
+Should be a combination of symbol, listed below. If a symbol is present in the string,
+ the corresponding unformatted file is written, containing the corresponding matric elements\\
+
+\begin{tabular}{r|c|c}
+{\tt 'a'} & {\tt seedname\_AA\_R} &  $\memnR{\rr }$. \\
+{\tt 'b'} & {\tt seedname\_BB\_R} &  $\memnR{H \cdot(\rr-\RR )}$.\\
+{\tt 'c'} & {\tt seedname\_CC\_R} &  $\memnR{r_\alpha\cdot H \cdot (r_\beta-R_\beta ) }$.\\
+{\tt 'f'} & {\tt seedname\_FF\_R} &  $\memnR{r_\alpha \cdot (r_\beta-R_\beta ) }$.\\
+{\tt 's'} & {\tt seedname\_SS\_R} &  $\memnR{\mathbf{\sigma}} $.\\\hline
+\multirow{3}{*}{{\tt 'h'}} & {\tt seedname\_SR\_R}  & $\memnR{ \sigma_\alpha \cdot(r_\beta-R_\beta)}$\\
+                           & {\tt seedname\_SHR\_R} & $\memnR{ \sigma_\alpha \cdot H \cdot(r_\beta-R_\beta)}$\\
+                           & {\tt seedname\_SH\_R}  & $\memnR{ \sigma_\alpha \cdot H }$\\
+\end{tabular}
+
+The default value is an empty string (no additional files written)
+
+
+%  complex(kind=dp), allocatable, save :: HH_R(:, :, :) !  <0n|r|Rm>
+%  !! $$\langle 0n | H | Rm \rangle$$
+%
+%  complex(kind=dp), allocatable, save :: AA_R(:, :, :, :) ! <0n|r|Rm>
+%  !! $$\langle 0n |  \hat{r} | Rm \rangle$$
+%
+%  complex(kind=dp), allocatable, save :: BB_R(:, :, :, :) ! <0|H(r-R)|R>
+%  !! $$\langle 0n | H(\hat{r}-R) | Rm \rangle$$
+%
+%  complex(kind=dp), allocatable, save :: CC_R(:, :, :, :, :) ! <0|r_alpha.H(r-R)_beta|R>
+%  !! $$\langle 0n | \hat{r}_{\alpha}.H.(\hat{r}- R)_{\beta} | Rm \rangle$$
+%
+%  complex(kind=dp), allocatable, save :: FF_R(:, :, :, :, :) ! <0|r_alpha.(r-R)_beta|R>
+%  !! $$\langle 0n | \hat{r}_{\alpha}.(\hat{r}-R)_{\beta} | Rm \rangle$$
+%
+%  complex(kind=dp), allocatable, save :: SS_R(:, :, :, :) ! <0n|sigma_x,y,z|Rm>
+%  !! $$\langle 0n | \sigma_{x,y,z} | Rm \rangle$$
+%
+%  complex(kind=dp), allocatable, save :: SR_R(:, :, :, :, :) ! <0n|sigma_x,y,z.(r-R)_alpha|Rm>
+%  !! $$\langle 0n | \sigma_{x,y,z}.(\hat{r}-R)_{\alpha}  | Rm \rangle$$
+%
+%  complex(kind=dp), allocatable, save :: SHR_R(:, :, :, :, :) ! <0n|sigma_x,y,z.H.(r-R)_alpha|Rm>
+%  !! $$\langle 0n | \sigma_{x,y,z}.H.(\hat{r}-R)_{\alpha}  | Rm \rangle$$
+%
+%  complex(kind=dp), allocatable, save :: SH_R(:, :, :, :) ! <0n|sigma_x,y,z.H|Rm>
+%  !! $$\langle 0n | \sigma_{x,y,z}.H  | Rm \rangle$$
 
 
 

--- a/doc/user_guide/user_guide.tex
+++ b/doc/user_guide/user_guide.tex
@@ -156,6 +156,7 @@
 \def\eps{\epsilon}
 \def\vareps{\varepsilon}
 \def\alfa{{\mathfrak a}}
+\def\memnR#1{\me{0m}{#1}{\RR n}}
 \newcommand{\eq}[1]{Eq.~(\ref{eq:#1})}
 \newcommand{\eqs}[2]{Eqs.~(\ref{eq:#1}) and~(\ref{eq:#2})}
 

--- a/doc/wannier90.bib
+++ b/doc/wannier90.bib
@@ -594,6 +594,12 @@ title={{Tight-Binding Formalism in the Context of the PythTB Package}},
 howpublished={\url{http://physics.rutgers.edu/pythtb/formalism.html}}
 }
 
+@misc{wannier-berri,
+title={{\tt wannier-berri} code},
+howpublished={\url{https://github.com/stepan-tsirkin/wannier-berri}}
+}
+
+
 @article{Marianetti,
 title = {Selectively localized Wannier functions},
 author = {Wang, Runzhi and Lazar, Emanuel A. and Park, Hyowon and Millis, Andrew J. and Marianetti, Chris A.},

--- a/src/parameters.F90
+++ b/src/parameters.F90
@@ -168,10 +168,9 @@ module w90_parameters
   integer, public, save :: kslice_2dkmesh(2)
   character(len=20), public, save :: kslice_fermi_lines_colour
 
-  ! to save the ??_R atrices 
+  ! to save the ??_R atrices
   character(len=20), public, save :: get_oper_save_task
   logical, public, save :: get_oper_save
-
 
   ! module  d o s
   logical, public, save    :: dos
@@ -1178,12 +1177,11 @@ contains
         .and. index(berry_task, 'shc') == 0) call io_error &
       ('Error: value of berry_task not recognised in param_read')
 
-   ! Stepan 
+    ! Stepan
     get_oper_save = .false.
     call param_get_keyword('get_oper_save', found, l_value=get_oper_save)
     get_oper_save_task = ''
     call param_get_keyword('get_oper_save_task', found, c_value=get_oper_save_task)
-
 
     ! Stepan
     gyrotropic = .false.

--- a/src/parameters.F90
+++ b/src/parameters.F90
@@ -168,6 +168,11 @@ module w90_parameters
   integer, public, save :: kslice_2dkmesh(2)
   character(len=20), public, save :: kslice_fermi_lines_colour
 
+  ! to save the ??_R atrices 
+  character(len=20), public, save :: get_oper_save_task
+  logical, public, save :: get_oper_save
+
+
   ! module  d o s
   logical, public, save    :: dos
 ! No need to save 'dos_plot', only used here (introduced 'dos_task')
@@ -1172,6 +1177,13 @@ contains
         .and. index(berry_task, 'kubo') == 0 .and. index(berry_task, 'sc') == 0 &
         .and. index(berry_task, 'shc') == 0) call io_error &
       ('Error: value of berry_task not recognised in param_read')
+
+   ! Stepan 
+    get_oper_save = .false.
+    call param_get_keyword('get_oper_save', found, l_value=get_oper_save)
+    get_oper_save_task = ''
+    call param_get_keyword('get_oper_save_task', found, c_value=get_oper_save_task)
+
 
     ! Stepan
     gyrotropic = .false.
@@ -6169,6 +6181,8 @@ contains
     call comms_bcast(berry_curv_adpt_kmesh_thresh, 1)
     call comms_bcast(berry_curv_unit, len(berry_curv_unit))
 !  Stepan Tsirkin
+    call comms_bcast(get_oper_save, 1)
+    call comms_bcast(get_oper_save_task, len(get_oper_save_task))
     call comms_bcast(gyrotropic, 1)
     call comms_bcast(gyrotropic_task, len(gyrotropic_task))
     call comms_bcast(gyrotropic_kmesh_spacing, 1)

--- a/src/postw90/get_oper.F90
+++ b/src/postw90/get_oper.F90
@@ -26,7 +26,7 @@ module w90_get_oper
 
   public
 
-  private :: fourier_q_to_R, get_win_min
+  private :: fourier_q_to_R, get_win_min, save_matrix
 
   complex(kind=dp), allocatable, save :: HH_R(:, :, :) !  <0n|r|Rm>
   !! $$\langle 0n | H | Rm \rangle$$
@@ -1444,6 +1444,99 @@ contains
 
   end subroutine get_SHC_R
 
+
+!!   Subroutine to save the real-space matrices, to be read by wannier-berri code  (Stepan Tsirkin)
+  subroutine get_oper_save_main
+
+    use w90_parameters, only: num_wann, real_lattice, get_oper_save_task, spinors
+    use w90_postw90_common, only: nrpts, irvec, ndegen
+
+    use w90_constants, only: dp
+    use w90_io, only: io_error, stdout, io_stopwatch, &
+      io_file_unit, seedname
+    use w90_parameters, only: num_wann
+    use w90_comms, only: on_root
+    use w90_ws_distance, only: ws_write_vec_wberri
+
+    character(len=10) :: suffix
+
+    integer :: file_unit, i, j
+
+    call get_HH_R
+    suffix = "HH"
+    call save_matrix(suffix, mat0d=HH_R)
+
+    if (on_root) then
+      file_unit = io_file_unit()
+      open (file_unit, file=trim(seedname)//"_R.info", form='formatted', status='unknown')
+
+      write (file_unit,'(2I8,L8,A)') num_wann, nrpts, spinors, "    # num_wann , nrpts, spinors"
+
+      do i = 1, 3
+        write (file_unit, '(3F20.12)') real_lattice(i, 1:3)
+      enddo
+
+      do i = 1, nrpts
+        write (file_unit, '(4I8)') (irvec(j, i), j=1, 3), ndegen(i)
+      enddo
+
+!!   Now write the ws_vec information
+
+      call ws_write_vec_wberri(nrpts, irvec, file_unit)
+
+      close (file_unit)
+
+    endif
+
+    if (index(get_oper_save_task, 'a') > 0) then
+      call get_AA_R
+      suffix = "AA"
+      call save_matrix(suffix, mat1d=AA_R)
+    endif
+
+    if (index(get_oper_save_task, 'b') > 0) then
+      call get_BB_R
+      suffix = "BB"
+      call save_matrix(suffix, mat1d=BB_R)
+    endif
+
+    if (index(get_oper_save_task, 'c') > 0) then
+      call get_CC_R
+      suffix = "CC"
+      call save_matrix(suffix, mat2d=CC_R)
+    endif
+
+    if (index(get_oper_save_task, 'f') > 0) then
+      call get_FF_R
+      suffix = "FF"
+      call save_matrix(suffix, mat2d=FF_R)
+    endif
+
+    if (spinors) then
+
+      if (index(get_oper_save_task, 's') > 0) then
+        call get_SS_R
+        suffix = "SS"
+        call save_matrix(suffix, mat1d=SS_R)
+      endif
+
+      if (index(get_oper_save_task, 'h') > 0) then
+        call get_SHC_R
+        suffix = "SR"
+        call save_matrix(suffix, mat2d=SR_R)
+        suffix = "SHR"
+        call save_matrix(suffix, mat2d=SHR_R)
+        suffix = "SH"
+        call save_matrix(suffix, mat1d=SH_R)
+      endif
+
+    endif ! spinors
+
+  end subroutine get_oper_save_main
+
+
+
+
   !=========================================================!
   !                   PRIVATE PROCEDURES                    !
   !=========================================================!
@@ -1557,5 +1650,53 @@ contains
                         v_matrix(1:ns_b, 1:num_wann, ik_b), 'N', &
                         S, eigval(wm_a:wm_a + ns_a - 1, ik_a), H)
   end subroutine get_gauge_overlap_matrix
+
+
+  !!   Subroutine to save the real-space matrices, to be read by wannier-berri code  (Stepan Tsirkin)
+  !==========================================================
+  subroutine save_matrix(file_suffix, mat0d, mat1d, mat2d)
+    !==========================================================
+    use w90_constants, only: dp
+    use w90_io, only: io_error, stdout, io_stopwatch, &
+      io_file_unit, seedname
+    use w90_parameters, only: num_wann
+    use w90_comms, only: on_root, comms_bcast
+
+    complex(kind=dp), dimension(:, :, :), intent(in), optional :: mat0d
+    complex(kind=dp), dimension(:, :, :, :), intent(in), optional :: mat1d
+    complex(kind=dp), dimension(:, :, :, :, :), intent(in), optional :: mat2d
+    character(len=10), intent(in) :: file_suffix
+
+    integer :: i, j, m, n, file_unit
+    character(len=120) :: file_name
+
+    if (on_root) then
+
+      file_name = trim(seedname)//"_"//trim(file_suffix)//'_R'
+      write (stdout, '(/a)') ' writing to file  ' &
+        //file_name
+      file_unit = io_file_unit()
+      open (file_unit, file=trim(file_name), form='unformatted', status='unknown')
+
+      do m = 1, num_wann
+        do n = 1, num_wann
+          if (present(mat0d)) then
+            write (file_unit) mat0d(m, n, :)
+          elseif (present(mat1d)) then
+            write (file_unit) mat1d(m, n, :, :)
+          elseif (present(mat2d)) then
+            write (file_unit) mat2d(m, n, :, :, :)
+          else
+            call io_error("get_oper :: save_matrix "" no matrix given for saving")
+          endif
+        enddo
+      enddo
+
+      close (file_unit)
+
+    endif ! on_root
+
+  end subroutine save_matrix
+
 
 end module w90_get_oper

--- a/src/postw90/get_oper.F90
+++ b/src/postw90/get_oper.F90
@@ -1444,7 +1444,6 @@ contains
 
   end subroutine get_SHC_R
 
-
 !!   Subroutine to save the real-space matrices, to be read by wannier-berri code  (Stepan Tsirkin)
   subroutine get_oper_save_main
 
@@ -1470,7 +1469,7 @@ contains
       file_unit = io_file_unit()
       open (file_unit, file=trim(seedname)//"_R.info", form='formatted', status='unknown')
 
-      write (file_unit,'(2I8,L8,A)') num_wann, nrpts, spinors, "    # num_wann , nrpts, spinors"
+      write (file_unit, '(2I8,L8,A)') num_wann, nrpts, spinors, "    # num_wann , nrpts, spinors"
 
       do i = 1, 3
         write (file_unit, '(3F20.12)') real_lattice(i, 1:3)
@@ -1533,9 +1532,6 @@ contains
     endif ! spinors
 
   end subroutine get_oper_save_main
-
-
-
 
   !=========================================================!
   !                   PRIVATE PROCEDURES                    !
@@ -1651,7 +1647,6 @@ contains
                         S, eigval(wm_a:wm_a + ns_a - 1, ik_a), H)
   end subroutine get_gauge_overlap_matrix
 
-
   !!   Subroutine to save the real-space matrices, to be read by wannier-berri code  (Stepan Tsirkin)
   !==========================================================
   subroutine save_matrix(file_suffix, mat0d, mat1d, mat2d)
@@ -1697,6 +1692,5 @@ contains
     endif ! on_root
 
   end subroutine save_matrix
-
 
 end module w90_get_oper

--- a/src/postw90/postw90.F90
+++ b/src/postw90/postw90.F90
@@ -31,6 +31,7 @@ program postw90
   use w90_spin
   use w90_kpath
   use w90_kslice
+  use w90_get_oper, only:  get_oper_save_main
 
   use w90_boltzwann
   use w90_geninterp
@@ -184,6 +185,12 @@ program postw90
   endif
   !
   ! Now perform one or more of the following tasks
+
+
+ !!   save the real-space matrices, to be read by wannier-berri code  (Stepan Tsirkin)
+
+  if (get_oper_save)  call get_oper_save_main
+
 
   ! ---------------------------------------------------------------
   ! Density of states calculated using a uniform interpolation mesh

--- a/src/postw90/postw90.F90
+++ b/src/postw90/postw90.F90
@@ -31,7 +31,7 @@ program postw90
   use w90_spin
   use w90_kpath
   use w90_kslice
-  use w90_get_oper, only:  get_oper_save_main
+  use w90_get_oper, only: get_oper_save_main
 
   use w90_boltzwann
   use w90_geninterp
@@ -186,11 +186,9 @@ program postw90
   !
   ! Now perform one or more of the following tasks
 
+  !!   save the real-space matrices, to be read by wannier-berri code  (Stepan Tsirkin)
 
- !!   save the real-space matrices, to be read by wannier-berri code  (Stepan Tsirkin)
-
-  if (get_oper_save)  call get_oper_save_main
-
+  if (get_oper_save) call get_oper_save_main
 
   ! ---------------------------------------------------------------
   ! Density of states calculated using a uniform interpolation mesh

--- a/src/postw90/postw90_common.F90
+++ b/src/postw90/postw90_common.F90
@@ -284,6 +284,8 @@ contains
     call comms_bcast(gyrotropic_smr_max_arg, 1)
     call comms_bcast(gyrotropic_smr_fixed_en_width, 1)
     call comms_bcast(gyrotropic_smr_index, 1)
+    call comms_bcast(get_oper_save, 1)
+    call comms_bcast(get_oper_save_task, len(get_oper_save_task))
 
     call comms_bcast(spinors, 1)
 

--- a/src/ws_distance.F90
+++ b/src/ws_distance.F90
@@ -320,7 +320,7 @@ contains
   end subroutine ws_write_vec
   !====================================================!
 
-! Stepan Tsirkin 
+! Stepan Tsirkin
   subroutine ws_write_vec_wberri(nrpts, irvec, file_unit)
     !! Write to file the lattice vectors of the superlattice
     !! to be added to R vector in seedname_HH_R file (read by wannier-berri)
@@ -365,8 +365,6 @@ contains
     !====================================================!
   end subroutine ws_write_vec_wberri
   !====================================================!
-
-
 
   !====================================================!
   subroutine clean_ws_translate()


### PR DESCRIPTION
Dear Wannier90 developers team, 

The present pull request adds some routines, which optionally  write the arrays AA_R, BB_R, CC_R, HH_R, SS_R and others evaluated within the get_oper.F90  to binary files.  This files are aimed to be be read by the wannier-berri python package, that I am developing.  
I also added to the manual the description of the 2 new variables, which  switch on this feature.
No other functionality of wannier90 or postw90 is affected. 

Best Regards,
Stepan