### PR TITLE
fix the issue in plot_bvec

### DIFF
--- a/src/plot.F90
+++ b/src/plot.F90
@@ -1702,7 +1702,6 @@ contains
     character(len=9)  :: cdate, ctime
     !
     file_unit = io_file_unit()
-    open (file_unit, file=trim(seedname)//'.bvec', form='formatted', status='unknown', err=101)
     call io_date(cdate, ctime)
     header = 'written on '//cdate//' at '//ctime
     !
@@ -1711,7 +1710,7 @@ contains
     write (file_unit, *) num_kpts, nntot
     do nkp = 1, num_kpts
       do nn = 1, nntot
-        write (file_unit, '(4F12.6)') bk(:, nn, nkp), wb(nn)
+        write (file_unit, '(4F14.8)') bk(:, nn, nkp), wb(nn)
       enddo
     enddo
     close (file_unit)

--- a/src/wannier_lib.F90
+++ b/src/wannier_lib.F90
@@ -387,7 +387,7 @@ subroutine wannier_run(seed__name, mp_grid_loc, num_kpts_loc, &
   time2 = io_time()
   write (stdout, '(1x,a25,f11.3,a)') 'Time for wannierise      ', time2 - time1, ' (sec)'
 
-  if (wannier_plot .or. bands_plot .or. fermi_surface_plot .or. write_hr) then
+  if (wannier_plot .or. bands_plot .or. fermi_surface_plot .or. write_hr .or. write_bvec) then
     call plot_main()
     time1 = io_time()
     write (stdout, '(1x,a25,f11.3,a)') 'Time for plotting        ', time1 - time2, ' (sec)'


### PR DESCRIPTION
Dear all:

This commit fixes the issue in writing *.bvec file which is necessary for the evaluation of velocity matrix elements in EPW.
Previously, the writing of bvec file is triggered by the input flags which are not directly related to it.
Additionally, I removed one of two open statements and increased the number of significant digits in *.bvec file so that it matches those from kmesh.pl .

On behalf of the EPW developers' team,
Hyungjun Lee