### PR TITLE
Very minor issue in the subroutine of internal_cube_format in plot.F90

### DIFF
--- a/src/plot.F90
+++ b/src/plot.F90
@@ -1494,11 +1494,11 @@ contains
         endif
         ! Number of grid points in each direction, lattice vector
         write (file_unit, '(i4,3f13.5)') ilength(1), real_lattice(1, 1)/(real(ngx, dp)*bohr), &
-          real_lattice(1, 2)/(real(ngy, dp)*bohr), real_lattice(1, 3)/(real(ngz, dp)*bohr)
-        write (file_unit, '(i4,3f13.5)') ilength(2), real_lattice(2, 1)/(real(ngx, dp)*bohr), &
-          real_lattice(2, 2)/(real(ngy, dp)*bohr), real_lattice(2, 3)/(real(ngz, dp)*bohr)
-        write (file_unit, '(i4,3f13.5)') ilength(3), real_lattice(3, 1)/(real(ngx, dp)*bohr), &
-          real_lattice(3, 2)/(real(ngy, dp)*bohr), real_lattice(3, 3)/(real(ngz, dp)*bohr)
+          real_lattice(1, 2)/(real(ngx, dp)*bohr), real_lattice(1, 3)/(real(ngx, dp)*bohr)
+        write (file_unit, '(i4,3f13.5)') ilength(2), real_lattice(2, 1)/(real(ngy, dp)*bohr), &
+          real_lattice(2, 2)/(real(ngy, dp)*bohr), real_lattice(2, 3)/(real(ngy, dp)*bohr)
+        write (file_unit, '(i4,3f13.5)') ilength(3), real_lattice(3, 1)/(real(ngz, dp)*bohr), &
+          real_lattice(3, 2)/(real(ngz, dp)*bohr), real_lattice(3, 3)/(real(ngz, dp)*bohr)
 
         ! Atomic number, valence charge, position of atom
 !         do isp=1,num_species


### PR DESCRIPTION
Dear all:

There were very minor typos(?) in the subroutine of internal_cube_format in plot.F90:
ngx, ngy, and ngz correspond to dffts%nr1, dffts%nr2, and dffts%nr3, respectively. That is, ngx is the number of grids along the first direct lattice vector, etc.

Sincerely,

Hyungjun Lee