### PR TITLE
fix typo in documentation of wannier_plot_spinor_mode parameter

### DIFF
--- a/doc/user_guide/parameters.tex
+++ b/doc/user_guide/parameters.tex
@@ -1282,10 +1282,10 @@ If $\verb#spinors#=\verb#true#$ then this parameter controls the
 quantity to plot. For a spinor WF with components $[\phi,\psi]$ the quatity plotted is
 \begin{itemize}
 \item[{\bf --}] \verb#total# (default). $\sqrt{[|\phi|^2+|\psi|^2}$
-\item[{\bf --}] \verb#up#. $|\phi|\times sign(Re\{\phi\})$ if $\verb#wannier_plot_spinor_mode#=\verb#true#$,
+\item[{\bf --}] \verb#up#. $|\phi|\times sign(Re\{\phi\})$ if $\verb#wannier_plot_spinor_phase#=\verb#true#$,
  otherwise $|\phi|$
 \item[{\bf --}] \verb#down#. $|\psi|\times sign(Re\{\psi\})$ if
-  $\verb#wannier_plot_spinor_mode#=\verb#true#$, otherwise $|\psi|$
+  $\verb#wannier_plot_spinor_phase#=\verb#true#$, otherwise $|\psi|$
 \end{itemize}
 Note: making a visual representation of a spinor WF is not as
 straightforward as for a scalar WF. While  a scalar WF is typically a


### PR DESCRIPTION
There are 2 typos in the doc of section 2.9.8 `wannier_plot_spinor_mode`, should be 
- up. |φ| × sign(Re{φ}) if wannier_plot_spinor_**phase** = true, otherwise |φ|

instead of 
- up. |φ| × sign(Re{φ}) if wannier_plot_spinor_**mode** = true, otherwise |φ|

According to code:
https://github.com/wannier-developers/wannier90/blob/10e54f32fc2ca7ddfcffc2eb34ae1fc45a86da2d/src/plot.F90#L1169-L1181