### PR TITLE
run workflows explicitly on Ubuntu 20.04 with `numprocs=2`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,3 +59,11 @@ jobs:
           ./.github/workflows/run_tests.sh
       - name: compute coverage
         uses: codecov/codecov-action@v1
+      - name: archive test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results_parallel=${{ matrix.w90-binary-parallel }}
+          path: |
+            test-suite/tests/test*/test.err*
+            test-suite/tests/test*/test.out*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,14 +10,14 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - uses: pre-commit/action@v2.0.0
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         w90-binary-parallel: [ 'false', 'true' ]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: pre-commit/action@v2.0.0
 
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         w90-binary-parallel: [ 'false', 'true' ]

--- a/.github/workflows/run_tests.sh
+++ b/.github/workflows/run_tests.sh
@@ -37,5 +37,5 @@ then
     echo "**************************"
     # I hardcode the numprocs to four, in case change it or set it as an ENV
     # var in the .travis.yml
-    ./run_tests --category=default --numprocs=4
+    ./run_tests --category=default --numprocs=2
 fi


### PR DESCRIPTION
attempts to close #361