### PR TITLE
update pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.2.3
+  rev: v4.1.0
   hooks:
   - id: check-yaml
   - id: trailing-whitespace
@@ -13,7 +13,7 @@ repos:
         config/make[.]inc[.\w]*|
         examples/example\d\d[-]?\w*/.+win
       )$
-- repo: git://github.com/pseewald/fprettify
+- repo: https://github.com/pseewald/fprettify
   rev: v0.3.3
   hooks:
   - id: fprettify


### PR DESCRIPTION
Closes #407. Also updates some pre-commit hooks to the latest version.

We may want to consider moving to https://pre-commit.ci/, and remove the [pre-commit action](https://github.com/pre-commit/action), as it has been deprecated.