### PR TITLE
Provide cmake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,377 @@
+# using 3.18 to have nice lapack imported target
+cmake_minimum_required(VERSION 3.18)
+
+project(wannier90
+  LANGUAGES C CXX Fortran
+  VERSION 3.1.0
+  HOMEPAGE_URL http://www.wannier.org/
+  DESCRIPTION "Computational chemistry package for computing maximally-localised Wannier functions.")
+
+#
+# Build options
+#
+
+# Do we want want shared or static libraries ?
+option(WANNIER_SHARED_LIB "Build shared library ? (Default: OFF, i.e. static libraries)" OFF)
+
+# build doc ?
+option(BUILD_DOC "Build doc ?" OFF)
+
+# Travis CI enabled ?
+option(TRAVISCI_ENABLED "Use custom flags for Travis CI ? (Default: OFF)" OFF)
+
+#
+# Export compile command to json (for editors like emacs, clion, vim, etc...).
+# It allows nice code editing features provided by LSP (Language Server Protocol)
+#
+set(CMAKE_EXPORT_COMPILE_COMMANDS on)
+
+#
+# default local cmake macro repository (located in wannier90 top level sources)
+#
+list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+#
+# Enforce user to use a build directory outside of source tree
+#
+include(prevent_in_source_build)
+prevent_in_source_build()
+
+#
+# Set default compile optimization flag
+#
+set(wannier90_BUILD_TYPE "Release" CACHE STRING
+  "Optimization flags: set to Debug, Release, RelWithDebInfo, or MinSizeRel")
+
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE "${wannier90_BUILD_TYPE}" CACHE INTERNAL "" FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif ()
+
+#
+# Mixing Fortran and C
+#
+include(FortranCInterface)
+FortranCInterface_VERIFY()
+FortranCInterface_HEADER(
+  fc_mangle.h
+  MACRO_NAMESPACE "FC_"
+  )
+
+string(TOLOWER ${CMAKE_BUILD_TYPE} build_type)
+if (build_type STREQUAL debug)
+  set(DEBUG_MODE 1)
+endif()
+
+#------------------------------------------------------------------------------#
+#
+# Additional compiler flags, compiler specific
+#
+#------------------------------------------------------------------------------#
+include(SetupCompiler)
+
+
+# BLAS / LAPACK setup
+#
+# this is controlled by cmake var BLA_VENDOR
+# available values slightly depends on cmake version
+# currently in cmake 3.18, valid values are
+#
+#    Goto
+#    OpenBLAS
+#    FLAME
+#    ATLAS PhiPACK
+#    CXML
+#    DXML
+#    SunPerf
+#    SCSL
+#    SGIMATH
+#    IBMESSL
+#    Intel10_32 (intel mkl v10 32 bit)
+#    Intel10_64lp (intel mkl v10+ 64 bit, threaded code, lp64 model)
+#    Intel10_64lp_seq (intel mkl v10+ 64 bit, sequential code, lp64 model)
+#    Intel10_64ilp (intel mkl v10+ 64 bit, threaded code, ilp64 model)
+#    Intel10_64ilp_seq (intel mkl v10+ 64 bit, sequential code, ilp64 model)
+#    Intel10_64_dyn (intel mkl v10+ 64 bit, single dynamic library)
+#    Intel (obsolete versions of mkl 32 and 64 bit)
+#    ACML
+#    ACML_MP
+#    ACML_GPU
+#    Apple
+#    NAS
+#    Arm
+#    Arm_mp
+#    Arm_ilp64
+#    Arm_ilp64_mp
+#    Generic
+#
+# NOTE:
+# - if variable BLA_VENDOR is not set, all vendors are considered.
+# - if multiple implementation are available on your system, the first to be detected,
+#   will be considered
+#
+# Recommended value for MKL : Intel10_32
+#
+# Example
+# - cmake configure step (from source top-level)
+#   cmake -DBLA_VENDOR=OpenBLAS -S . -B build/openblas
+# - cmake build project
+#   cmake --build build/openblas
+#
+# See doc https://cmake.org/cmake/help/latest/manual/cmake.1.html
+#
+find_package(BLAS)
+find_package(LAPACK)
+if (NOT BLAS_FOUND OR NOT LAPACK_FOUND)
+  message(fatal_error "BLAS or LAPACK were not found, please adjust variable BLA_VENDOR to select blas/lapack implementation and/or install blas/lapack implementation.")
+endif()
+
+#
+# MPI
+#
+set(MPI_DETERMINE_LIBRARY_VERSION TRUE)
+find_package(MPI COMPONENTS Fortran)
+
+#
+# check MPI fortran interface
+#
+if(MPI_FOUND)
+  add_compile_definitions(MPI)
+
+  if (MPI_Fortran_HAVE_F08_MODULE)
+    add_compile_definitions(MPI08)
+    message("MPI fortran interface f08 supported, MPI_Fortran_MODULE_DIR=${MPI_Fortran_MODULE_DIR}")
+  elseif(MPI_Fortran_HAVE_F90_MODULE)
+    add_compile_definitions(MPIF90)
+  elseif(MPI_Fortran_HAVE_F77_HEADER)
+    add_compile_definitions(MPIH)
+  else()
+    # default to f90 style "use mpi"
+    add_compile_definitions(MPIF90)
+  endif()
+
+endif(MPI_FOUND)
+
+# determine mpi vendor (MPI_VENDOR)
+# valid values are : OpenMPI, MPICH or IntelMPI
+include(get_mpi_vendor)
+get_mpi_vendor()
+
+if (NOT DEFINED MPI_VERSION AND DEFINED MPI_Fortran_VERSION)
+  set(MPI_VERSION ${MPI_Fortran_VERSION})
+  set(MPI_VERSION_MAJOR ${MPI_Fortran_VERSION_MAJOR})
+  set(MPI_VERSION_MINOR ${MPI_Fortran_VERSION_MINOR})
+endif()
+
+#
+# OpenMP
+#
+find_package(OpenMP)
+
+
+##################### PRINT CONFIGURE STATUS ######################
+message("//===================================================")
+message("// ${PROJECT_NAME} build configuration:")
+message("// ${PROJECT_NAME} version : ${PROJECT_VERSION}")
+message("//===================================================")
+message("  CMake version          : ${CMAKE_VERSION}")
+if (NOT CMAKE_BUILD_TYPE)
+  message("  CMake build type       : NOT SET !")
+else()
+  message("  CMake build type       : ${CMAKE_BUILD_TYPE}")
+endif()
+message("  CMake install prefix   : ${CMAKE_INSTALL_PREFIX}")
+message("  CMake system processor : ${CMAKE_SYSTEM_PROCESSOR}")
+message("  CMake system name (OS) : ${CMAKE_SYSTEM_NAME}")
+message("")
+
+message("  Fortran compiler Id      : ${CMAKE_Fortran_COMPILER_ID}")
+message("  Fortran compiler version : ${CMAKE_Fortran_COMPILER_VERSION}")
+message("  Fortran compiler exe     : ${CMAKE_Fortran_COMPILER}")
+message("  Fortran flags            : ${CMAKE_Fortran_FLAGS}")
+message("  Fortran compiler wrapper : ${CMAKE_Fortran_COMPILER_WRAPPER}")
+message("")
+
+message(STATUS "MPI config:")
+message("    MPI found            : ${MPI_FOUND}")
+message("    MPI standard version : ${MPI_Fortran_VERSION}")
+# note : make sure you correctly your C, C++ and Fortran compiler
+# through variable CC, CXX and FC
+message("    MPI_VENDOR           : ${MPI_VENDOR}")
+message("    MPI library version  : ${MPI_Fortran_LIBRARY_VERSION_STRING}")
+message("    MPI fortran compiler : ${MPI_Fortran_COMPILER}")
+message("    MPI headers          : ${MPI_Fortran_INCLUDE_DIRS}")
+message("    MPI libraries        : ${MPI_Fortran_LIBRARIES}")
+#message("    MPI link flags       : ${MPI_Fortran_LINK_FLAGS}")
+message("    MPI module dir       : ${MPI_Fortran_MODULE_DIR}")
+message("")
+
+message(STATUS "OpenMP config :")
+message("    OpenMP found         : ${OpenMP_FOUND}")
+message("    OpenMP version       : ${OpenMP_Fortran_VERSION}")
+message("")
+
+message(STATUS "BLAS config:")
+message("  BLA_VENDOR : ${BLA_VENDOR}")
+if (BLAS_FOUND)
+  message("  BLAS_LINKER_FLAGS : ${BLAS_LINKER_FLAGS}")
+  message("  BLAS_LIBRARIES    : ${BLAS_LIBRARIES}")
+else()
+  message("  BLAS not found ! Please recheck your environment variables.")
+endif()
+message("")
+
+message(STATUS "LAPACK config:")
+message("  BLA_VENDOR : ${BLA_VENDOR}")
+if (LAPACK_FOUND)
+  message("  LAPACK_LINKER_FLAGS : ${LAPACK_LINKER_FLAGS}")
+  message("  LAPACK_LIBRARIES    : ${LAPACK_LIBRARIES}")
+else()
+  message("  LAPACK not found ! Please recheck your environment variables.")
+endif()
+message("")
+
+if (DEFINED ENV{PKG_CONFIG_PATH})
+  message(STATUS "ENV{PKG_CONFIG_PATH} was :")
+  message("    $ENV{PKG_CONFIG_PATH}")
+  message("")
+else()
+  message(STATUS "ENV{PKG_CONFIG_PATH} was empty")
+  message("")
+endif()
+
+if (DEFINED ENV{CMAKE_PREFIX_PATH})
+  message(STATUS "ENV{CMAKE_PREFIX_PATH} was :")
+  message("    $ENV{CMAKE_PREFIX_PATH}")
+  message("")
+else()
+  message(STATUS "ENV{CMAKE_PREFIX_PATH} was empty")
+  message("")
+endif()
+
+# --- make git ignore build directory
+if(NOT EXISTS ${PROJECT_BINARY_DIR}/.gitignore)
+  file(WRITE ${PROJECT_BINARY_DIR}/.gitignore "*")
+endif()
+
+add_subdirectory(src)
+add_subdirectory(utility)
+
+if (BUILD_DOC)
+  find_package(LATEX COMPONENTS PDFLATEX BIBTEX)
+
+  if (LATEX_FOUND)
+    add_subdirectory(doc)
+    add_custom_target(doc DEPENDS doc_tutorial doc_user_guide)
+    add_custom_target(doc_clean DEPENDS doc_tutorial_clean doc_user_guide_clean)
+    add_custom_target(doc_veryclean DEPENDS doc_tutorial_veryclean doc_user_guide_veryclean)
+  else()
+    message(FATAL_ERROR "pdflatex not found; can't build documentation. Turn OFF BUILD_DOC or install pdflatex.")
+  endif()
+
+endif(BUILD_DOC)
+
+#
+# dist targets
+#
+find_package(Git QUIET)
+
+if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
+  set(tarfile ${PROJECT_NAME}-${PROJECT_VERSION}.tar.gz)
+  add_custom_command(
+    OUTPUT ${tarfile}
+    COMMAND ${GIT_EXECUTABLE} archive HEAD --prefix=${PROJECT_NAME}-${PROJECT_VERSION}/ -o ${CMAKE_BINARY_DIR}/${tarfile}
+    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+    )
+  add_custom_target(dist DEPENDS "${PROJECT_NAME}-${PROJECT_VERSION}.tar.gz")
+endif()
+
+# gnu compatibility,
+# see https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
+include(GNUInstallDirs)
+
+# used to install libwannier
+set(INSTALL_TARGETS wannier)
+
+################################# EXPORT CONFIG #################################
+include(CMakePackageConfigHelpers)
+
+# setup some variables
+set(version_config ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake)
+set(project_config_src ${PROJECT_SOURCE_DIR}/${PROJECT_NAME}-config.cmake.in)
+set(project_config_dst ${PROJECT_BINARY_DIR}/${PROJECT_NAME}-config.cmake)
+set(targets_export_name ${PROJECT_NAME}-targets)
+
+# important variables
+set(INSTALL_BINDIR ${CMAKE_INSTALL_BINDIR} CACHE STRING
+  "Installation directory for executables, relative to ${CMAKE_INSTALL_PREFIX}.")
+
+set(INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR} CACHE STRING
+  "Installation directory for libraries, relative to ${CMAKE_INSTALL_PREFIX}.")
+
+set(INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR} CACHE STRING
+  "Installation directory for include files, relative to ${CMAKE_INSTALL_PREFIX}.")
+
+set(INSTALL_PKGCONFIG_DIR ${CMAKE_INSTALL_LIBDIR}/pkgconfig CACHE PATH
+  "Installation directory for pkgconfig (.pc) files, relative to ${CMAKE_INSTALL_PREFIX}.")
+
+set(INSTALL_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake CACHE STRING
+  "Installation directory for cmake files, relative to ${CMAKE_INSTALL_PREFIX}.")
+
+# Generate the version, config and target files into the build directory.
+write_basic_package_version_file(
+  ${version_config}
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY AnyNewerVersion)
+
+# Generate cmake my_package-config.cmake file
+configure_package_config_file(
+  ${project_config_src}
+  ${project_config_dst}
+  INSTALL_DESTINATION ${INSTALL_CMAKE_DIR})
+  # Use a namespace because CMake provides better diagnostics
+  # for namespaced imported targets.
+export(
+  TARGETS ${INSTALL_TARGETS} NAMESPACE wannier::
+  FILE ${PROJECT_BINARY_DIR}/${targets_export_name}.cmake)
+
+# macro helper to generate pkg-config file
+include(generate_pkgconfig)
+
+# generate the pkg-config file wannier90.pc
+generate_pkgconfig(wannier90)
+
+################################# INSTALL LIBRARY #################################
+
+# install executables
+install(
+  TARGETS wannier90.x postw90.x w90chk2chk.x w90spn2spn.x
+  RUNTIME DESTINATION ${INSTALL_BINDIR}
+  COMPONENT bin
+  )
+
+# install libwannier
+install(
+  TARGETS ${INSTALL_TARGETS}
+  EXPORT ${targets_export_name}
+  ARCHIVE DESTINATION ${INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  )
+
+# install cmake config and targets
+install(
+  FILES ${project_config_dst} ${version_config}
+  DESTINATION ${INSTALL_CMAKE_DIR})
+
+install(
+  EXPORT ${targets_export_name}
+  DESTINATION ${INSTALL_CMAKE_DIR}
+  NAMESPACE wannier::)
+
+# install pkgconfig
+install(
+  FILES ${CMAKE_BINARY_DIR}/${PROJECT_NAME}.pc
+  DESTINATION "${INSTALL_PKGCONFIG_DIR}")

--- a/cmake/SetupCompiler.cmake
+++ b/cmake/SetupCompiler.cmake
@@ -1,0 +1,15 @@
+if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
+
+  if (TRAVISCI_ENABLED)
+    add_compile_options(
+      "$<$<COMPILE_LANGUAGE:Fortran>:-fprofile-arcs;-ftest-coverage;-fstrict-aliasing;-fno-omit-frame-pointer;-fno-realloc-lhs;-fcheck=bounds,do,recursion,pointer;-ffree-form;-Wall;-Waliasing;-Wsurprising;-Wline-truncation;-Wno-tabs;-Wno-uninitialized;-Wno-unused-dummy-argument;-Wno-unused;-Wno-character-truncation;-O1;-g;-fbacktrace>")
+
+    add_link_options(
+      "$<$<COMPILE_LANGUAGE:Fortran>:-fprofile-arcs;-ftest-coverage;-fstrict-aliasing;-fno-omit-frame-pointer;-fno-realloc-lhs;-fcheck=bounds,do,recursion,pointer;-ffree-form;-Wall;-Waliasing;-Wsurprising;-Wline-truncation;-Wno-tabs;-Wno-uninitialized;-Wno-unused-dummy-argument;-Wno-unused;-Wno-character-truncation;-O1;-g;-fbacktrace>")
+  endif()
+
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "NAG")
+
+  add_compile_definitions(NAG)
+
+endif()

--- a/cmake/generate_pkgconfig.cmake
+++ b/cmake/generate_pkgconfig.cmake
@@ -1,0 +1,24 @@
+macro(generate_pkgconfig name)
+
+  # about pkg-config
+  # set variables as required by autotools
+  set (VERSION ${PROJECT_VERSION})
+  set (prefix ${CMAKE_INSTALL_PREFIX})
+  set (exec_prefix ${CMAKE_INSTALL_FULL_BINDIR})
+  set (libdir ${CMAKE_INSTALL_FULL_LIBDIR})
+  set (includedir ${CMAKE_INSTALL_FULL_INCLUDEDIR})
+
+  # actually produce the pkg-config file
+  configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/${name}.pc.in
+    ${CMAKE_CURRENT_BINARY_DIR}/${name}.pc
+    @ONLY
+    )
+
+  unset (VERSION)
+  unset (prefix)
+  unset (exec_prefix)
+  unset (libdir)
+  unset (includedir)
+
+endmacro(generate_pkgconfig)

--- a/cmake/get_mpi_vendor.cmake
+++ b/cmake/get_mpi_vendor.cmake
@@ -1,0 +1,17 @@
+function(get_mpi_vendor)
+
+    execute_process(COMMAND mpirun --version OUTPUT_VARIABLE MPIRUN_OUTPUT)
+
+    string(FIND "${MPIRUN_OUTPUT}" "Open MPI" OMPI_POS)
+    string(FIND "${MPIRUN_OUTPUT}" "MPICH" MPICH_POS)
+    string(FIND "${MPIRUN_OUTPUT}" "Intel(R) MPI" IMPI_POS)
+
+    if(NOT OMPI_POS STREQUAL "-1")
+      set(MPI_VENDOR "OpenMPI" PARENT_SCOPE)
+    elseif(NOT MPICH_POS STREQUAL "-1")
+      set(MPI_VENDOR "MPICH" PARENT_SCOPE)
+    elseif(NOT IMPI_POS STREQUAL "-1")
+      set(MPI_VENDOR "IntelMPI" PARENT_SCOPE)
+    endif()
+
+endfunction()

--- a/cmake/prevent_in_source_build.cmake
+++ b/cmake/prevent_in_source_build.cmake
@@ -1,0 +1,19 @@
+function(prevent_in_source_build)
+
+  # make sure the user doesn't play dirty with symlinks
+  get_filename_component(srcdir "${CMAKE_SOURCE_DIR}" REALPATH)
+  get_filename_component(bindir "${CMAKE_BINARY_DIR}" REALPATH)
+
+  # disallow in-source builds
+  if("${srcdir}" STREQUAL "${bindir}")
+    message("######################################################")
+    message("# ${PROJECT_NAME} should not be configured and built in the source directory")
+    message("# You must run cmake in a build directory.")
+    message("# For example:")
+    message("# mkdir build ; cd build")
+    message("# run cmake from the build directory.")
+    message("######################################################")
+    message(FATAL_ERROR "Quitting configuration")
+  endif()
+
+endfunction(prevent_in_source_build)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(tutorial)
+add_subdirectory(user_guide)

--- a/doc/tutorial/CMakeLists.txt
+++ b/doc/tutorial/CMakeLists.txt
@@ -1,0 +1,32 @@
+add_custom_command(
+  OUTPUT tutorial.pdf
+  COMMAND ${CMAKE_COMMAND} -E echo "Building tutorial.pdf"
+  COMMAND ${PDFLATEX_COMPILER} tutorial.tex
+  COMMAND ${BIBTEX_COMPILER}   tutorial
+  COMMAND ${PDFLATEX_COMPILER} tutorial.tex
+  COMMAND ${BIBTEX_COMPILER}   tutorial
+  COMMAND ${PDFLATEX_COMPILER} tutorial.tex
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  DEPENDS tutorial.tex
+  COMMENT "Generating tutorial.pdf with pdflatex")
+
+add_custom_target(doc_tutorial DEPENDS tutorial.pdf)
+
+#
+# add clean and veryclean target
+#
+file(GLOB tutorial_clean_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} CONFIGURE_DEPENDS "*.aux" "*.log" "*.bbl" "*.blg" "*.lot" "*.lof" "*.toc" "*.dvi" "*.bak" "*~" "*.ps")
+message("[wannier90/doc/tutorial] files to clean : ${tutorial_clean_files}")
+
+add_custom_command(
+  OUTPUT clean_tutorial
+  COMMAND rm -f ${tutorial_clean_files}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_custom_command(
+  OUTPUT veryclean_tutorial
+  COMMAND rm -f tutorial.pdf
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_custom_target(doc_tutorial_clean DEPENDS clean_tutorial)
+add_custom_target(doc_tutorial_veryclean DEPENDS clean_tutorial veryclean_tutorial)

--- a/doc/user_guide/CMakeLists.txt
+++ b/doc/user_guide/CMakeLists.txt
@@ -1,0 +1,32 @@
+add_custom_command(
+  OUTPUT user_guide.pdf
+  COMMAND ${CMAKE_COMMAND} -E echo "Building user_guide.pdf"
+  COMMAND ${PDFLATEX_COMPILER} user_guide.tex
+  COMMAND ${BIBTEX_COMPILER}   user_guide
+  COMMAND ${PDFLATEX_COMPILER} user_guide.tex
+  COMMAND ${BIBTEX_COMPILER}   user_guide
+  COMMAND ${PDFLATEX_COMPILER} user_guide.tex
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  DEPENDS user_guide.tex
+  COMMENT "Generating user_guide.pdf with pdflatex")
+
+add_custom_target(doc_user_guide DEPENDS user_guide.pdf)
+
+#
+# add clean and veryclean target
+#
+file(GLOB user_guide_clean_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} CONFIGURE_DEPENDS "*.aux" "*.log" "*.bbl" "*.blg" "*.lot" "*.lof" "*.toc" "*.dvi" "*.bak" "*~" "*.ps")
+message("[wannier90/doc/user_guide] files to clean : ${user_guide_clean_files}")
+
+add_custom_command(
+  OUTPUT clean_user_guide
+  COMMAND rm -f ${user_guide_clean_files}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_custom_command(
+  OUTPUT veryclean_user_guide
+  COMMAND rm -f user_guide.pdf
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_custom_target(doc_user_guide_clean DEPENDS clean_user_guide)
+add_custom_target(doc_user_guide_veryclean DEPENDS clean_user_guide veryclean_user_guide)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,138 @@
+#
+# common lib
+#
+add_library(wannier_common OBJECT
+  constants.F90
+  io.F90
+  utility.F90
+  types.F90
+  hamiltonian.F90
+  overlap.F90
+  kmesh.F90
+  disentangle.F90
+  ws_distance.F90
+  wannierise.F90
+  plot.F90
+  transport.F90
+  sitesym.F90
+  comms.F90
+  wannier90_types.F90
+  wannier90_readwrite.F90
+  readwrite.F90
+  error.F90
+  error_base.F90)
+
+if (MPI_FOUND)
+  target_link_libraries(wannier_common PUBLIC
+    MPI::MPI_Fortran)
+endif()
+
+#
+# post lib
+#
+add_library(wannier_post OBJECT
+  ws_distance.F90
+  types.F90
+  kmesh.F90
+  io.F90
+  comms.F90
+  utility.F90
+  postw90/get_oper.F90
+  constants.F90
+  postw90/postw90_common.F90
+  postw90/wan_ham.F90
+  postw90/spin.F90
+  postw90/dos.F90
+  postw90/berry.F90
+  postw90/gyrotropic.F90
+  postw90/kpath.F90
+  postw90/kslice.F90
+  postw90/boltzwann.F90
+  postw90/geninterp.F90
+  postw90/postw90_types.F90
+  postw90/postw90_readwrite.F90
+  readwrite.F90
+  error.F90
+  error_base.F90)
+if (MPI_FOUND)
+  target_link_libraries(wannier_post PUBLIC
+    MPI::MPI_Fortran)
+endif()
+
+
+#
+# lib wan2
+#
+add_library(wan2
+  $<TARGET_OBJECTS:wannier_common>)
+if (MPI_FOUND)
+  target_link_libraries(wan2 PUBLIC
+    MPI::MPI_Fortran)
+endif()
+add_library(wannier::wan2 ALIAS wan2)
+
+#
+# libwannier
+#
+add_library(wannier
+  $<TARGET_OBJECTS:wannier_common>
+  wannier_lib.F90)
+if (MPI_FOUND)
+  target_link_libraries(wannier PUBLIC
+    MPI::MPI_Fortran)
+endif()
+add_library(wannier::wannier ALIAS wannier)
+
+#
+# move libwannier and libwan2 to top-level bin dir
+#
+set_target_properties(wannier wan2
+  PROPERTIES
+  LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
+
+#
+# Executables
+#
+
+# w90chk2chk.x
+add_executable(w90chk2chk.x
+  w90chk2chk.F90)
+
+target_link_libraries(w90chk2chk.x PUBLIC
+  wannier::wan2
+  )
+
+# w90spn2spn.x
+add_executable(w90spn2spn.x
+  w90spn2spn.F90)
+
+target_link_libraries(w90spn2spn.x PUBLIC
+  wannier::wan2
+  )
+
+# wannier90.x
+add_executable(wannier90.x
+  wannier_prog.F90)
+
+target_link_libraries(wannier90.x PUBLIC
+  wannier::wan2
+  BLAS::BLAS
+  LAPACK::LAPACK)
+
+# postw90.x
+add_executable(postw90.x
+  $<TARGET_OBJECTS:wannier_post>
+  postw90/postw90.F90)
+if (MPI_FOUND)
+  target_link_libraries(postw90.x PUBLIC
+    MPI::MPI_Fortran
+    BLAS::BLAS
+    LAPACK::LAPACK)
+endif()
+
+#
+# move wannier90.x and postw90.x to top-level bin dir
+#
+set_target_properties(wannier90.x postw90.x
+  PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")

--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(w90pov)
+add_subdirectory(w90vdw)

--- a/utility/w90pov/CMakeLists.txt
+++ b/utility/w90pov/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_executable(w90pov.x
+  src/main.f90
+  src/general.f90
+  src/io.f90
+  src/write_df3.c
+  src/driver.f90)

--- a/utility/w90vdw/CMakeLists.txt
+++ b/utility/w90vdw/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(w90vdw.x
+  w90vdw.f90)

--- a/wannier90-config.cmake.in
+++ b/wannier90-config.cmake.in
@@ -1,0 +1,127 @@
+# wannierConfig.cmake
+# ------------------
+#
+# wannier cmake module.
+# This module sets the following variables in your project:
+#
+# ::
+#
+##   wannier_FOUND - true if wannier and all required components found on the system
+##   wannier_VERSION - wannier version in format Major.Minor.Release
+##   wannier_INCLUDE_DIRS - Directories where wannier header is located.
+##   wannier_INCLUDE_DIR - same as DIRS
+##   wannier_DEFINITIONS: Definitions necessary to use wannier, namely USING_wannier.
+##   wannier_LIBRARIES - wannier library to link against.
+##   wannier_LIBRARY - same as LIBRARIES
+#
+#
+# Available components: shared static
+#
+# ::
+#
+#   shared - search for only shared library
+#   static - search for only static library
+#
+#
+## Exported targets:
+##
+## ::
+##
+## If wannier is found, this module defines the following :prop_tgt:`IMPORTED`
+## target. Note that if wannier library is static, importing project must
+## declare Fortran as a language in order to populate the link libs. ::
+##
+##   wannier::wannier - the main wannier library with header, defs, & linker lang attached.
+##
+##
+## Suggested usage:
+##
+## ::
+##
+##   find_package(wannier)
+##   find_package(wannier 3.1 EXACT CONFIG REQUIRED)
+#
+#
+# The following variables can be set to guide the search for this package:
+#
+# ::
+#
+#   wannier_DIR - CMake variable, set to directory containing this Config file
+#   CMAKE_PREFIX_PATH - CMake variable, set to root directory of this package
+#   PATH - environment variable, set to bin directory of this package
+#   CMAKE_DISABLE_FIND_PACKAGE_wannier - CMake variable, disables
+#     find_package(wannier) when not REQUIRED, perhaps to force internal build
+
+@PACKAGE_INIT@
+
+set(PN wannier)
+set (_valid_components
+    static
+    shared
+)
+
+# find includes
+# unset(_temp_h CACHE)
+# find_path(_temp_h
+#           NAMES wannier/wannier.h
+#           PATHS ${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@
+#           NO_DEFAULT_PATH)
+# if(_temp_h)
+#     set(${PN}_INCLUDE_DIR "${_temp_h}")
+#     set(${PN}_INCLUDE_DIRS ${${PN}_INCLUDE_DIR})
+# else()
+#     set(${PN}_FOUND 0)
+#     if(NOT CMAKE_REQUIRED_QUIET)
+#         message(STATUS "${PN}Config missing component: header (${PN}: ${_temp_h})")
+#     endif()
+# endif()
+
+# find library: shared, static, or whichever
+set(_hold_library_suffixes ${CMAKE_FIND_LIBRARY_SUFFIXES})
+list(FIND ${PN}_FIND_COMPONENTS "shared" _seek_shared)
+list(FIND ${PN}_FIND_COMPONENTS "static" _seek_static)
+if(_seek_shared GREATER -1)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_SHARED_LIBRARY_SUFFIX})
+elseif(_seek_static GREATER -1)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_STATIC_LIBRARY_SUFFIX})
+endif()
+unset(_temp CACHE)
+find_library(_temp
+             NAMES wannier
+             PATHS ${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@
+             NO_DEFAULT_PATH)
+if(_temp)
+    set(${PN}_LIBRARY "${_temp}")
+    if(_seek_shared GREATER -1)
+        set(${PN}_shared_FOUND 1)
+    elseif(_seek_static GREATER -1)
+        set(${PN}_static_FOUND 1)
+    endif()
+else()
+    if(_seek_shared GREATER -1)
+        if(NOT CMAKE_REQUIRED_QUIET)
+            message(STATUS "${PN}Config missing component: shared library (${PN}: ${_temp})")
+        endif()
+    elseif(_seek_static GREATER -1)
+        if(NOT CMAKE_REQUIRED_QUIET)
+            message(STATUS "${PN}Config missing component: static library (${PN}: ${_temp})")
+        endif()
+    else()
+        set(${PN}_FOUND 0)
+        if(NOT CMAKE_REQUIRED_QUIET)
+            message(STATUS "${PN}Config missing component: library (${PN}: ${_temp})")
+        endif()
+    endif()
+endif()
+set(CMAKE_FIND_LIBRARY_SUFFIXES ${_hold_library_suffixes})
+set(${PN}_LIBRARIES ${${PN}_LIBRARY})
+
+check_required_components(${PN})
+
+#-----------------------------------------------------------------------------
+# Don't include targets if this file is being picked up by another
+# project which has already built this as a subproject
+#-----------------------------------------------------------------------------
+if(NOT TARGET ${PN}::${PN})
+    include("${CMAKE_CURRENT_LIST_DIR}/${PN}Targets.cmake")
+endif()

--- a/wannier90.pc.in
+++ b/wannier90.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: wannier
+Description: Computational chemistry package for computing maximally-localised Wannier functions.
+Requires:
+Version: @VERSION@
+Libs: -L${libdir} -lwannier
+Cflags: -I${includedir}


### PR DESCRIPTION
I'd like to contribute a cmake build system for wannier.

I've tried to mimic as much as as possible the existing Makefile build (including building doc, making dist tarfile and satisfying make install).

I've tested 2 build chains: gfortran and nvhpc

example of use for gfortran:
```shell
mkdir build/gfortran
cd build/gfortran
cmake -DCMAKE_INSTALL_PREFIX=/opt/local/wannier-3.1.0 ../..
make -j 4
make install
```

One can choose a compiler toolchain simply by setting env variables CC and FC (which is usually done via modulefiles on a supercomputer).

It also allows easy ways to use wannier library by providing
-  either by using pkgconfig : users just need to add `$INSTALL_DIR/lib/pkgconfig` to env variable PKG_CONFIG_PATH to detect libwannier
-  either by using cmake-config files so that `find_package(wannier90)` will work; users just need to add `$INSTALL_DIR/lib/cmake` to env variable CMAKE_PREFIX_PATH to use libwannier in their own cmake projects

Finally it also eases other usages like integrate wannier cmake build into another cmake build, or use a dependencies manager like CPM.