### PR TITLE
Fix typo in tutorial about Tungsten

### DIFF
--- a/doc/tutorial/tutorial.tex
+++ b/doc/tutorial/tutorial.tex
@@ -3593,7 +3593,7 @@ Thus, we use a modified density matrix \cite{LinLin-ArXiv2017}, with the functio
                             a complementary error
                             function to the projectabilities. The number of MLWFs is given by the number
                             of pseudo-atomic orbitals (PAOs) in the pseudopotential, $21$ in this case. All the steps shown in this example have been automated in the AiiDA\cite{Pizzi_AiiDA} workflow that can be downloaded from the MaterialsCloud website\cite{MaterialsCloudArchiveEntry}}.}
-        \item{Directory: {\tt examples/example31/}}
+        \item{Directory: {\tt examples/example32/}}
         \item{Input files}
         \begin{itemize}
                 \item{ {\tt W.scf} {\it The \pwscf\ input file for ground state


### PR DESCRIPTION
The correct directory for Tungsten should be examples/example32