### PR TITLE
Call mpi_finalize in the end of postw90 dry run

### DIFF
--- a/src/postw90/postw90.F90
+++ b/src/postw90/postw90.F90
@@ -330,7 +330,12 @@ program postw90
       write (stdout, *) '                                   DRYRUN             '
       write (stdout, *) '                       No problems found with win file'
       write (stdout, *) '                       ==============================='
+      close (stdout)
+      close (stderr, status='delete') ! this should not be unit 0
     endif
+#ifdef MPI
+    call mpi_finalize(ierr)
+#endif
     stop
   endif
 


### PR DESCRIPTION
This fixes #346 to avoid incorrect termination when dryrun is done with MPI.