### PR TITLE
Add missing author

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,6 +123,7 @@ In addition to the Wannier90 Developer Group, the other authors of Wannier90 v.3
 * Lorenzo Paulatto (Sorbonne Paris, FR): Improvements to the interpolation routines, non-collinear spin with ultrasoft in pw2wannier90
 * Samuel Poncé (Oxford University, GB): Test suite for Wannier90
 * Thomas Ponweiser (RISC Software GmbH, AT): performance optimizations for postw90
+* Junfeng Qiao (EPFL, CH): spin Hall conductivity
 * Florian Thöle (ETHZ, CH): non-collinear spin with ultrasoft in pw2wannier90
 * Stepan Tsirkin (Universidad del Pais Vasco, ES): GW bands interpolation, gyrotropic module, shift-current calculation, bug fixes in the berry module
 * Małgorzata Wierzbowska (Polish Academy of Science, PL): performance optimizations for postw90

--- a/docs/docs/user_guide/introduction.md
+++ b/docs/docs/user_guide/introduction.md
@@ -77,9 +77,9 @@ Daniel Marchand (EPFL, CH), Antimo Marrazzo (EPFL, CH), Yuriy Mokrousov
 (FZ Jülich, DE), Jamal I. Mustafa (UC Berkeley, USA), Yoshiro Nohara
 (Tokyo, JP), Yusuke Nomura (U. Tokyo, JP), Lorenzo Paulatto (Sorbonne
 Paris, FR), Samuel Poncé (Oxford University, GB), Thomas Ponweiser (RISC
-Software GmbH, AT), Florian Thöle (ETHZ, CH), Stepan Tsirkin
-(Universidad del Pais Vasco, ES), Małgorzata Wierzbowska (Polish Academy
-of Science, PL).
+Software GmbH, AT), Junfeng Qiao (EPFL, CH), Florian Thöle (ETHZ, CH),
+Stepan Tsirkin (Universidad del Pais Vasco, ES), Małgorzata Wierzbowska
+(Polish Academy of Science, PL).
 
 Contributors to the code include: Daniel Aberg (w90pov code), Lampros
 Andrinopoulos (w90vdw code), Pablo Aguado Puente (gyrotropic routines),


### PR DESCRIPTION
Order according to the author list of w90v3 paper.

Checked again now everyone is included.