### PR TITLE
Fix bounds error when assigning M matrices

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       - name: install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install  \
+          sudo apt-get -y install  \
             gfortran            \
             libblas-dev         \
             liblapack-dev       \

--- a/src/readwrite.F90
+++ b/src/readwrite.F90
@@ -2103,7 +2103,7 @@ contains
     ikl = 1
     do ikg = 1, num_kpts
       if (distk(ikg) == rank) then
-        m_matrix_local(:, :, :, ikl) = m_matrix(:, :, :, ikg)
+        m_matrix_local(:num_wann, :num_wann, :, ikl) = m_matrix(:, :, :, ikg)
         ikl = ikl + 1
       endif
     enddo


### PR DESCRIPTION
With gfortran `-fcheck=bounds` the chkpt distribution raise a runtime error:

```
Array bound mismatch for dimension 1 of array 'm_matrix_local' (12/8)
```

This fixs test failure of #486.