### PR TITLE
Fix merge issue503

### DIFF
--- a/src/postw90/postw90.F90
+++ b/src/postw90/postw90.F90
@@ -405,7 +405,7 @@ program postw90
   ! Setup a number of common variables for all interpolation tasks
 
   call pw90common_wanint_setup(num_wann, verbose, real_lattice, mp_grid, effective_model, &
-                               ws_vec, stdout, seedname, timer, error, comm)
+                               ws_region, ws_vec, stdout, seedname, timer, error, comm)
   if (allocated(error)) call prterr(error, ierr, stdout, stderr, comm)
 
   if (on_root) then

--- a/src/postw90/pw90_library.F90
+++ b/src/postw90/pw90_library.F90
@@ -273,8 +273,9 @@ contains
 
     ierr = 0
     call pw90common_wanint_setup(wann90%num_wann, wann90%print_output, wann90%real_lattice, &
-                                 wann90%mp_grid, pw90%effective_model, pw90%ws_vec, istdout, &
-                                 wann90%seedname, wann90%timer, error, wann90%comm)
+                                 wann90%mp_grid, pw90%effective_model, wann90%ws_region, &
+                                 pw90%ws_vec, istdout, wann90%seedname, wann90%timer, error, &
+                                 wann90%comm)
     if (allocated(error)) then
       write (istderr, *) 'Error in post setup', error%code, error%message
       ierr = sign(1, error%code)


### PR DESCRIPTION
Issue #503 contains two unrelated problems.

The parallelisation of the plot routine for generating xsf files was broken after a later merge that affected how the k-point distribution is handled (passed as an argument instead of being regenerated locally).   This is corrected with a simple cycle condition and passing the k-distribution list.

A second, earlier commit that applied the ws_distance method to postw90 (mirroring its use in hamiltonian.F90) was apparently reverted in entirety (see discussion in issue #503 ); it is fixed by replaying those changes and merging.