### PR TITLE
Fixes for make -j

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ REALMAKEFILE=../Makefile.2
 
 TAR := $(shell if which gnutar 1>/dev/null 2> /dev/null; then echo gnutar; else echo tar; fi )
 
+.NOTPARALLEL:
 default: wannier post
 
 PREFIX ?= /usr

--- a/src/Makefile.2
+++ b/src/Makefile.2
@@ -160,7 +160,7 @@ sitesym.o : ../sitesym.F90 utility.o types.o constants.o wannier90_types.o
 comms.o: ../comms.F90 constants.o error_base.o ../../make.inc
 	 $(COMPILER) $(POSTOPTS) $(FCOPTS) -c ../comms.F90
 
-boltzwann.o: $(POSTDIR)boltzwann.F90 constants.o types.o io.o utility.o postw90_common.o get_oper.o wan_ham.o comms.o spin.o dos.o postw90_types.o ws_distance.o
+boltzwann.o: $(POSTDIR)boltzwann.F90 constants.o types.o io.o utility.o postw90_common.o get_oper.o wan_ham.o comms.o spin.o dos.o postw90_types.o ws_distance.o postw90_readwrite.o
 	 $(COMPILER) $(POSTOPTS) $(FCOPTS) -c $(POSTDIR)boltzwann.F90
 
 geninterp.o: $(POSTDIR)geninterp.F90 constants.o types.o io.o get_oper.o postw90_common.o comms.o utility.o wan_ham.o postw90_types.o ws_distance.o
@@ -196,7 +196,7 @@ postw90_common.o: $(POSTDIR)postw90_common.F90 postw90_types.o ws_distance.o com
 postw90_types.o: $(POSTDIR)postw90_types.F90 comms.o types.o utility.o constants.o io.o
 	$(COMPILER) $(POSTOPTS) $(FCOPTS) -c $(POSTDIR)postw90_types.F90
 
-postw90_readwrite.o: $(POSTDIR)postw90_readwrite.F90 comms.o postw90_types.o types.o utility.o constants.o io.o error.o
+postw90_readwrite.o: $(POSTDIR)postw90_readwrite.F90 comms.o postw90_types.o types.o utility.o constants.o io.o error.o wannier90_readwrite.o
 	$(COMPILER) $(POSTOPTS) $(FCOPTS) -c $(POSTDIR)postw90_readwrite.F90
 
 .PHONY: wannier libs post clean mpi_test w90spn2spn


### PR DESCRIPTION
Add in command to top level makefile to stop make -j from threading over tasks. make -jN works correctly now. (note there is essentially no speed up after -j4). This fixes #516 


Also adds in some missing postw90 dependancies which were preventing 'make postw90' from succeeding in the case that Wannier was not previously built.