### PR TITLE
Fix write_tb with MPI

### DIFF
--- a/src/wannier_prog.F90
+++ b/src/wannier_prog.F90
@@ -265,6 +265,7 @@ program wannier
   need_eigvals = common_data%w90_calculation%bands_plot
   need_eigvals = (need_eigvals .or. common_data%w90_calculation%fermi_surface_plot)
   need_eigvals = (need_eigvals .or. common_data%output_file%write_hr)
+  need_eigvals = (need_eigvals .or. common_data%output_file%write_tb)
   need_eigvals = (need_eigvals .or. ldsnt) ! disentanglement anyway requires evals
 
   if (need_eigvals) then


### PR DESCRIPTION
Other cores need `eigval` array as well.

Traceback without this commit:

```
At line 371 of file ../hamiltonian.F90
Fortran runtime error: Index '4' of dimension 1 of array 'eigval' outside of expected range (1:1)

Error termination. Backtrace:
At line 371 of file ../hamiltonian.F90
Fortran runtime error: Index '4' of dimension 1 of array 'eigval' outside of expected range (1:1)

Error termination. Backtrace:
At line 371 of file ../hamiltonian.F90
Fortran runtime error: Index '4' of dimension 1 of array 'eigval' outside of expected range (1:1)

Error termination. Backtrace:
#0  0x7f1c19c15960 in ???
#1  0x7f1c19c164d9 in ???
#2  0x7f1c19c16ad6 in ???
#0  0x7f2abaf01960 in ???
#1  0x7f2abaf024d9 in ???
#2  0x7f2abaf02ad6 in ???
#0  0x7f34a03e9960 in ???
#1  0x7f34a03ea4d9 in ???
#2  0x7f34a03eaad6 in ???
#3  0x559ec7d193b1 in __w90_hamiltonian_MOD_hamiltonian_get_hr
        at ../hamiltonian.F90:371
#3  0x563ba87e33b1 in __w90_hamiltonian_MOD_hamiltonian_get_hr
        at ../hamiltonian.F90:371
#3  0x5608fca673b1 in __w90_hamiltonian_MOD_hamiltonian_get_hr
        at ../hamiltonian.F90:371
#4  0x563ba876854f in __w90_plot_mod_MOD_plot_main
        at ../plot.F90:172
#4  0x559ec7c9e54f in __w90_plot_mod_MOD_plot_main
        at ../plot.F90:172
#4  0x5608fc9ec54f in __w90_plot_mod_MOD_plot_main
        at ../plot.F90:172
#5  0x563ba86c7244 in __w90_library_MOD_w90_plot
        at ../library_interface.F90:748
#5  0x559ec7bfd244 in __w90_library_MOD_w90_plot
        at ../library_interface.F90:748
#5  0x5608fc94b244 in __w90_library_MOD_w90_plot
        at ../library_interface.F90:748
#6  0x563ba86a8be7 in wannier
        at ../wannier_prog.F90:304
#7  0x563ba86a92cd in main
        at ../wannier_prog.F90:59
#6  0x559ec7bdebe7 in wannier
        at ../wannier_prog.F90:304
#7  0x559ec7bdf2cd in main
        at ../wannier_prog.F90:59
#6  0x5608fc92cbe7 in wannier
        at ../wannier_prog.F90:304
#7  0x5608fc92d2cd in main
        at ../wannier_prog.F90:59
--------------------------------------------------------------------------
Primary job  terminated normally, but 1 process returned
a non-zero exit code. Per user-direction, the job has been aborted.
--------------------------------------------------------------------------
```
