### PR TITLE
Fixes to explicit_kpath code.

### DIFF
--- a/src/types.F90
+++ b/src/types.F90
@@ -237,7 +237,7 @@ module w90_types
     integer :: num_points_first_segment = 100
     character(len=20), allocatable :: labels(:)
     real(kind=dp), allocatable :: points(:, :)
-    logical :: bands_kpt_explicit ! use user provided list of kpoints for bands kpath
+    logical :: bands_kpt_explicit = .false. ! use user provided list of kpoints for bands kpath
     real(kind=dp), allocatable ::bands_kpt_frac(:, :) ! explicit bands kpoints in fractional coordinate
   end type kpoint_path_type
 

--- a/src/wannier90_readwrite.F90
+++ b/src/wannier90_readwrite.F90
@@ -279,11 +279,15 @@ contains
                                     error, comm)
       if (allocated(error)) return
 
-      if (.not. has_kpath) then
-        call w90_readwrite_read_explicit_kpath(settings, kpoint_path, has_explicit_kpath, w90_calculation%bands_plot, &
-                                               bohr, error, comm)
-        if (allocated(error)) return
+      call w90_readwrite_read_explicit_kpath(settings, kpoint_path, has_explicit_kpath, w90_calculation%bands_plot, &
+                                             bohr, error, comm)
+      if (allocated(error)) return
+
+      if (has_kpath .and. has_explicit_kpath) then
+        call set_error_input(error, 'Error: cannot specify both kpath and explicit_kpath', comm)
       endif
+      if (allocated(error)) return
+
       call w90_wannier90_readwrite_read_plot_info(settings, wvfn_read, error, comm)
       if (allocated(error)) return
 


### PR DESCRIPTION
Fixes a crash on osx+gfortran - the logical has_explicit_kpath was not initialised. This caused the test suite to fail on my MacBook. However, the issue wasn't picked up by the CI.

Also added a check incase explicit_kpath and kpath were both present in the input file.