### PR TITLE
chore: Update the Fedora image

### DIFF
--- a/.github/workflows/step_test.yaml
+++ b/.github/workflows/step_test.yaml
@@ -19,7 +19,7 @@ jobs:
       ${{ matrix.mpi && format('🖧 {0}', matrix.mpi) || '' }}
       ${{ matrix.experimental && '[🧪 Experimental]' || '' }}
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
-    container: ${{ !matrix.os && 'ghcr.io/lecrisut/dev-env:main' || '' }}
+    container: ${{ !matrix.os && format('ghcr.io/lecrisut/dev-env:latest-{0}', matrix.toolchain) || '' }}
     continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       fail-fast: false
@@ -40,7 +40,7 @@ jobs:
 #            experimental: false
     steps:
       - name: Install missing packages
-        run: sudo dnf install -y bzip2 python-unversioned-command which
+        run: sudo dnf install -y bzip2 python-unversioned-command which diff
       - name: Load mpi module ${{ matrix.mpi || '' }}
         run: |
           # Get interactive profile to be able to load modules


### PR DESCRIPTION
I've had some time to update my dev-env container and strip out the unused toolchains to make it load faster. I've also updated them to F42 which will test gcc-15 toolchains. #444 would be a better way to track the latest compilers, but that one can't test the intel compilers, so probably could still use this one (btw if there are cleaner ways to pull in the intel compilers, I'm up to refactor to use that instead)