### PR TITLE
memory bug fix, when more projection than wannier functions are specified

### DIFF
--- a/src/wannierise.F90
+++ b/src/wannierise.F90
@@ -413,7 +413,7 @@ contains
 
     ! initialise rguide to projection centres (Cartesians in units of Ang)
     if (wann_control%guiding_centres%enable) then
-      do n = 1, num_proj
+      do n = 1, min(num_wann, num_proj)
         call utility_frac_to_cart(wann_control%guiding_centres%centres(:, n), rguide(:, n), &
                                   real_lattice)
       enddo


### PR DESCRIPTION
I noticed, that wannier90.x may crash when more projections than Wannier functions are defined and only a subset is selected. I traced back the memory leak via valgrind to the changed line, which initially assumed, that num_wann >= num_proj. 

