### PR TITLE
Add CLA bot

### DIFF
--- a/.cla/version1/CLA.md
+++ b/.cla/version1/CLA.md
@@ -1,0 +1,102 @@
+# Contributor License Agreement
+
+> Adapted from the [Apache Software Foundation Individual Contributor License Agreement (ICLA)](https://www.apache.org/licenses/contributor-agreements.html) [version 2.2](https://www.apache.org/licenses/icla.pdf)
+
+You accept and agree to the following terms and conditions for Your
+Contributions (present and future) that you submit to the copyright
+holders (hereafter "HOLDERS", see the [`LICENSE`](../../LICENSE)
+bundled with this software). In return, the HOLDERS shall not use
+Your Contributions in a way that is contrary to the public benefit or
+inconsistent with its nonprofit status and bylaws in effect at the
+time of the Contribution. Except for the license granted herein to
+the HOLDERS and recipients of software distributed by the HOLDERS,
+You reserve all right, title, and interest in and to Your Contributions.
+
+1. Definitions.
+
+    "You" (or "Your") shall mean the copyright owner or legal entity
+    authorized by the copyright owner that is making this Agreement
+    with the HOLDERS. For legal entities, the entity making a
+    Contribution and all other entities that control, are controlled
+    by, or are under common control with that entity are considered to
+    be a single Contributor. For the purposes of this definition,
+    "control" means (i) the power, direct or indirect, to cause the
+    direction or management of such entity, whether by contract or
+    otherwise, or (ii) ownership of fifty percent (50%) or more of the
+    outstanding shares, or (iii) beneficial ownership of such entity.
+    "Contribution" shall mean any original work of authorship,
+    including any modifications or additions to an existing work, that
+    is intentionally submitted by You to the HOLDERS for inclusion
+    in, or documentation of, any of the products owned or managed by
+    the HOLDERS (the "Work"). For the purposes of this definition,
+    "submitted" means any form of electronic, verbal, or written
+    communication sent to the HOLDERS or its representatives,
+    including but not limited to communication on electronic mailing
+    lists, source code control systems, and issue tracking systems that
+    are managed by, or on behalf of, the HOLDERS for the purpose of
+    discussing and improving the Work, but excluding communication that
+    is conspicuously marked or otherwise designated in writing by You
+    as "Not a Contribution."
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+    this Agreement, You hereby grant to the HOLDERS and to
+    recipients of software distributed by the HOLDERS a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    copyright license to reproduce, prepare derivative works of,
+    publicly display, publicly perform, sublicense, and distribute Your
+    Contributions and such derivative works.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+    this Agreement, You hereby grant to the HOLDERS and to
+    recipients of software distributed by the HOLDERS a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    (except as stated in this section) patent license to make, have
+    made, use, offer to sell, sell, import, and otherwise transfer the
+    Work, where such license applies only to those patent claims
+    licensable by You that are necessarily infringed by Your
+    Contribution(s) alone or by combination of Your Contribution(s)
+    with the Work to which such Contribution(s) was submitted. If any
+    entity institutes patent litigation against You or any other entity
+    (including a cross-claim or counterclaim in a lawsuit) alleging
+    that your Contribution, or the Work to which you have contributed,
+    constitutes direct or contributory patent infringement, then any
+    patent licenses granted to that entity under this Agreement for
+    that Contribution or Work shall terminate as of the date such
+    litigation is filed.
+
+4. You represent that you are legally entitled to grant the above
+    license. If your employer(s) has rights to intellectual property
+    that you create that includes your Contributions, you represent
+    that you have received permission to make Contributions on behalf
+    of that employer, that your employer has waived such rights for
+    your Contributions to the HOLDERS, or that your employer has
+    executed a separate Corporate CLA with the HOLDERS.
+
+5. You represent that each of Your Contributions is Your original
+    creation (see section 7 for submissions on behalf of others). You
+    represent that Your Contribution submissions include complete
+    details of any third-party license or other restriction (including,
+    but not limited to, related patents and trademarks) of which you
+    are personally aware and which are associated with any part of Your
+    Contributions.
+
+6. You are not expected to provide support for Your Contributions,
+    except to the extent You desire to provide support. You may provide
+    support for free, for a fee, or not at all. Unless required by
+    applicable law or agreed to in writing, You provide Your
+    Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+    OF ANY KIND, either express or implied, including, without
+    limitation, any warranties or conditions of TITLE, NON-
+    INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+7. Should You wish to submit work that is not Your original creation,
+    You may submit it to the HOLDERS separately from any
+    Contribution, identifying the complete details of its source and of
+    any license or other restriction (including, but not limited to,
+    related patents, trademarks, and license agreements) of which you
+    are personally aware, and conspicuously marking the work as
+    "Submitted on behalf of a third-party: [named here]".
+
+8. You agree to notify the HOLDERS of any facts or circumstances of
+    which you become aware that would make these representations
+    inaccurate in any respect.

--- a/.cla/version1/signatures.json
+++ b/.cla/version1/signatures.json
@@ -1,0 +1,4 @@
+{
+  "signedContributors": [
+  ]
+}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,55 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.CLA_APP_ID }}
+          private-key: ${{ secrets.CLA_PRIVATE_KEY }}
+
+      - uses: contributor-assistant/github-action@v2.6.1
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby accept the CLA') || github.event_name == 'pull_request_target'
+        env:
+          # the default github token does not allow github action to create & push commit,
+          # instead, we need to use a github app to generate a token
+          # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          # the below token should have repo scope and must be manually added by you in the repository's secret
+          # This token is required only if you have configured to store the signatures in a remote repository/organization
+          # PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: ".cla/version1/signatures.json"
+          path-to-document: "https://github.com/wannier-developers/wannier90/blob/main/.cla/version1/CLA.md"
+          # branch should not be protected
+          branch: "main"
+          allowlist: bot*
+
+          # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
+          #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
+          #remote-repository-name: enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
+          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
+          #signed-commit-message: 'For example: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
+          custom-notsigned-prcomment: 'Thank you for your submission, we really appreciate it. Like many open-source projects, we ask that you accept our [Contributor License Agreement](https://github.com/wannier-developers/wannier90/blob/main/.cla/version1/CLA.md) before we can merge your contribution. You can accept the CLA by just copying the sentence below and posting it as a Pull Request Comment.'
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby accept the CLA'
+          custom-allsigned-prcomment: |
+            All contributors have accepted the CLA ✅
+
+            ---
+            <sub>You might need to click the "Update/Rebase branch" button to update the pull request and rerun the GitHub actions to pass the CLA check.</sub>
+          #lock-pullrequest-aftermerge: false - if you don't want this bot to automatically lock the pull request after merging (default - true)
+          #use-dco-flag: true - If you are using DCO instead of CLA


### PR DESCRIPTION
A GitHub bot that automatically requests signing contributor license agreement (CLA) for pull requests.