### PR TITLE
test strange yaml err

### DIFF
--- a/.github/workflows/step_test.yaml
+++ b/.github/workflows/step_test.yaml
@@ -26,6 +26,7 @@ jobs:
       matrix:
         toolchain: [ gcc ]
         mpi: [false, openmpi, mpich]
+        experimental: [false]
         include:
           - toolchain: intel
             mpi: false


### PR DESCRIPTION
(debugging a yaml/CI config error)

@LecrisUT  Hello again, Cristian!

strangely, inputs.mask-experimental doesn't seem to be defined in step_test.yaml -- could you take a quick look, please?  Unfortunately it's jammed the CI.