### PR TITLE
Fixes for Makefile and -DMPIH build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,14 @@ include make.inc
 
 REALMAKEFILE=../Makefile.2
 
+COMMS := $(strip $(COMMS))
+ifneq ($(filter mpi08 mpih mpi90 mpi,$(COMMS)),)
+  LIBSUFFIX = _mpi
+else
+  LIBSUFFIX =
+endif
+LIBRARYV2 = libwannier90$(LIBSUFFIX).a
+
 TAR := $(shell if which gnutar 1>/dev/null 2> /dev/null; then echo gnutar; else echo tar; fi )
 
 .NOTPARALLEL:
@@ -31,6 +39,10 @@ install: default
 	install -d $(DESTDIR)$(PREFIX)/lib/
 	if [ -f "$(LIBRARYV2)" ]; then install -m644 "$(LIBRARYV2)" "$(DESTDIR)$(PREFIX)/lib/$(LIBRARYV2)"; fi;
 	if [ -f "$(LIBRARYV2)" ]; then $(MAKE) pkgconfig; fi;
+	install -d $(DESTDIR)$(PREFIX)/include/
+	for m in src/obj/w90_library.mod src/obj/w90_library_extra.mod; do \
+		if [ -f "$$m" ]; then install -m644 "$$m" "$(DESTDIR)$(PREFIX)/include/"; fi; \
+	done
 
 all: wannier lib post w90chk2chk w90pov w90vdw w90spn2spn
 
@@ -64,17 +76,19 @@ libs: lib
 
 PKGCONFIG_FILENAME = wannier.pc
 pkgconfig:
-	$(file > $(PKGCONFIG_FILENAME),prefix=$(DESTDIR)$(PREFIX))
-	$(file >> $(PKGCONFIG_FILENAME),exec_prefix=$(DESTDIR)$(PREFIX)/bin)
-	$(file >> $(PKGCONFIG_FILENAME),libdir=$(DESTDIR)$(PREFIX)/lib)
-	$(file >> $(PKGCONFIG_FILENAME),includedir=$(DESTDIR)$(PREFIX)/include)
-	$(file >> $(PKGCONFIG_FILENAME),)
-	$(file >> $(PKGCONFIG_FILENAME),Name: wannier)
-	$(file >> $(PKGCONFIG_FILENAME),Description: Compute maximally-localised Wannier functions.)
-	$(file >> $(PKGCONFIG_FILENAME),Requires: )
-	$(file >> $(PKGCONFIG_FILENAME),Version: $(VERSION))
-	$(file >> $(PKGCONFIG_FILENAME),Libs: -L$${libdir} -lwannier)
-	$(file >> $(PKGCONFIG_FILENAME),Cflags: -I$${includedir})
+	{ \
+	  echo "prefix=$(DESTDIR)$(PREFIX)"; \
+	  echo "exec_prefix=$(DESTDIR)$(PREFIX)/bin"; \
+	  echo "libdir=$(DESTDIR)$(PREFIX)/lib"; \
+	  echo "includedir=$(DESTDIR)$(PREFIX)/include"; \
+	  echo ""; \
+	  echo "Name: wannier"; \
+	  echo "Description: Compute maximally-localised Wannier functions."; \
+	  echo "Requires: "; \
+	  echo "Version: $(VERSION)"; \
+	  echo 'Libs: -L$${libdir} -lwannier'; \
+	  echo 'Cflags: -I$${includedir}'; \
+	} > "$(PKGCONFIG_FILENAME)"
 	install -D -m644 "$(PKGCONFIG_FILENAME)" "$(DESTDIR)$(PREFIX)/lib/pkgconfig/$(PKGCONFIG_FILENAME)"
 	cd $(ROOTDIR) && rm -f $(PKGCONFIG_FILENAME)
 

--- a/src/wannier_prog.F90
+++ b/src/wannier_prog.F90
@@ -69,6 +69,10 @@ program wannier
 
   implicit none
 
+#ifdef MPIH
+  include 'mpif.h'
+#endif
+
   integer, parameter :: dp = kind(0.d0)
 
   character(len=:), allocatable :: seedname, progname, cpstatus


### PR DESCRIPTION
* Library not installed: LIBRARYV2 was only defined inside Makefile.header (included only during compilation). Added LIBSUFFIX/LIBRARYV2 definitions directly to the top-level Makefile, derived from the COMMS variable already read from make.inc, so the install target correctly resolves libwannier90.a (serial) or libwannier90_mpi.a (MPI).

* pkgconfig target broken on macOS: The $(file > ...) function requires GNU Make ≥ 4.0, but Xcode ships GNU Make 3.81. Those calls silently expanded to nothing, leaving wannier.pc unwritten and causing install to fail. Replaced with a portable { echo ...; } > shell block that works on all make versions.

* Fortran module files not installed: Added installation of w90_library.mod and w90_library_extra.mod from obj into $(PREFIX)/include/, so downstream projects can use the library interface by pointing their Fortran compiler at the installed include directory.

* Fix compilation with -DMPIH, `include 'mpif.h'` was missing in src/wannier_prog.F90
