### PR TITLE
cmake: add MPIH build option for legacy mpi.h interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ endif ()
 ]=============================================================================]
 
 option(WANNIER90_MPI "Wannier90: Build with MPI support" OFF)
+option(WANNIER90_MPIH "Wannier90: Build MPI support using the mpi.h header" OFF)
 option(WANNIER90_SHARED_LIBS "Wannier90: Build library as a shared library" ${PROJECT_IS_TOP_LEVEL})
 option(WANNIER90_INSTALL "Wannier90: Install files" ${PROJECT_IS_TOP_LEVEL})
 option(WANNIER90_TEST "Wannier90: Build test-suite" ${PROJECT_IS_TOP_LEVEL})
@@ -37,6 +38,10 @@ if (NOT CMAKE_Fortran_MODULE_DIRECTORY)
 	set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/fortran_mods)
 endif ()
 set(BUILD_SHARED_LIBS ${WANNIER90_SHARED_LIBS})
+
+if (WANNIER90_MPIH AND NOT WANNIER90_MPI)
+	message(FATAL_ERROR "WANNIER90_MPIH requires WANNIER90_MPI to be enabled")
+endif ()
 
 if (WANNIER90_INSTALL)
 	include(GNUInstallDirs)
@@ -67,6 +72,7 @@ endif ()
 ## Populate variables for FetchContent and sub-projects
 # All variables have to be consistent with CMakeExtraUtilsConfig.cmake
 set(Wannier90_MPI ${WANNIER90_WITH_MPI})
+set(Wannier90_MPIH ${WANNIER90_MPIH})
 
 #[=============================================================================[
 #                              External packages                              #
@@ -175,5 +181,6 @@ if (NOT PROJECT_IS_TOP_LEVEL)
 			Wannier90_VERSION_PATCH
 			Wannier90_VERSION_TWEAK
 			Wannier90_MPI
+			Wannier90_MPIH
 			)
 endif ()

--- a/cmake/Wannier90Config.cmake.in
+++ b/cmake/Wannier90Config.cmake.in
@@ -3,6 +3,7 @@
 
 ## Define basic variables
 set(Wannier90_MPI @WANNIER90_MPI@)
+set(Wannier90_MPIH @WANNIER90_MPIH@)
 
 ## Include dependencies
 include(CMakeFindDependencyMacro)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,15 +46,24 @@ target_sources(Wannier90_lib
 		${CMAKE_Fortran_MODULE_DIRECTORY}/w90_library.mod
 )
 if (WANNIER90_MPI)
+	set(_wannier90_mpi_interface MPI90)
+	if (WANNIER90_MPIH)
+		set(_wannier90_mpi_interface MPIH)
+	endif ()
+
 	target_link_libraries(Wannier90_lib PUBLIC MPI::MPI_Fortran)
 	target_compile_definitions(Wannier90_lib PRIVATE
 			# TODO: Use mpi_f08 instead. Tests are not adapted yet
-			MPI90 MPI
+			MPI ${_wannier90_mpi_interface}
 	)
 	target_compile_definitions(Wannier90_exe PRIVATE
 			# TODO: Use mpi_f08 instead. Tests are not adapted yet
-			MPI90 MPI
+			MPI ${_wannier90_mpi_interface}
 	)
+	if (WANNIER90_MPIH AND CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+		target_compile_options(Wannier90_lib PRIVATE -fallow-argument-mismatch)
+		target_compile_options(Wannier90_exe PRIVATE -fallow-argument-mismatch)
+	endif ()
 endif ()
 
 add_subdirectory(postw90)

--- a/src/library_interface.F90
+++ b/src/library_interface.F90
@@ -290,6 +290,10 @@ contains
 
     implicit none
 
+#ifdef MPIH
+    include 'mpif.h'
+#endif
+
     ! arguments
     character(len=*), intent(in) :: seedname
     integer, intent(in) :: istdout, istderr
@@ -1054,6 +1058,11 @@ contains
     use mpi_f08
 #endif
     implicit none
+
+#ifdef MPIH
+    include 'mpif.h'
+#endif
+
     type(lib_common_type), intent(inout) :: common_data
 #ifdef MPI08
     type(mpi_comm), intent(in) :: comm

--- a/src/postw90/CMakeLists.txt
+++ b/src/postw90/CMakeLists.txt
@@ -22,8 +22,11 @@ target_link_libraries(Wannier90_post PRIVATE
 if (WANNIER90_MPI)
 	target_compile_definitions(Wannier90_post PRIVATE
 			# TODO: Use mpi_f08 instead. Tests are not adapted yet
-			MPI90 MPI
+			MPI ${_wannier90_mpi_interface}
 	)
+	if (WANNIER90_MPIH AND CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+		target_compile_options(Wannier90_post PRIVATE -fallow-argument-mismatch)
+	endif ()
 endif ()
 
 ## Installs


### PR DESCRIPTION
Allow CMake builds to select the legacy mpif.h MPI interface instead of the default MPI90 module path, and apply the GNU Fortran compatibility flags needed for that configuration to build successfully.