### PR TITLE
fixup new makefile (COMMS=serial should not cause parallel tests)

### DIFF
--- a/Makefile.header
+++ b/Makefile.header
@@ -1,8 +1,7 @@
 # Do this before Makefile.header so we can annotate dynlib with COMMS
+# COMMS undefined for serial case
 ifdef COMMS
 COMMS := $(strip $(COMMS))
-else
-COMMS = serial
 endif
 
 POSTDIR = postw90/


### PR DESCRIPTION
fixes a makefile error causing parallel tests to be ran for a serial build