### PR TITLE
ensure a write statment only happens on mpi rank 0

### DIFF
--- a/src/readwrite.F90
+++ b/src/readwrite.F90
@@ -219,6 +219,7 @@ contains
     !! The array to be read must have num_kpt entries, with each entry being
     !! the MPI rank to which each k-point is assigned
     use w90_error, only: w90_error_type, set_error_input, set_error_alloc
+    use w90_comms, only: mpirank
     implicit none
 
     integer, allocatable, intent(inout) :: distk(:)
@@ -250,10 +251,12 @@ contains
       call w90_readwrite_get_range_vector(settings, 'distk', found, nk, .false., error, comm, distk)
       if (allocated(error)) return
     else
-      write (stdout, '(a)') 'Note: parallel distribution provided (option distk missing)'
-      write (stdout, '(a)') 'Note: all k-points handled by MPI rank 0'
-      allocate (distk(nkin))
-      distk = 0 ! default to no distribution if not specified
+      if (mpirank(comm) == 0) then !only print on root rank
+        write (stdout, '(a)') 'Note: no parallel distribution provided (option distk missing)'
+        write (stdout, '(a)') 'Note: all k-points handled by MPI rank 0'
+        allocate (distk(nkin))
+        distk = 0 ! default to no distribution if not specified
+      end if
     end if
   end subroutine w90_readwrite_read_distk
 
@@ -1197,7 +1200,6 @@ contains
     !
     ! (for _vector: just specify zero length)
     ! (for _block: small modification to skip checking/failure when rows=0 )
-    !use w90_io, only: io_error
     use w90_error, only: w90_error_type
 
     implicit none


### PR DESCRIPTION
mpi execution otherwise creates nuisance empty "fort.1" files.  This is a bugfix.