### PR TITLE
Fix overflow when num_proj > num_wann

### DIFF
--- a/src/wannier90_readwrite.F90
+++ b/src/wannier90_readwrite.F90
@@ -1606,6 +1606,12 @@ contains
 
       if (atom_data%num_species > 0) then
         ! only read projections if atom positions are known
+        ! Count pass first: num_proj may exceed num_wann when there are more initial
+        ! projections than target Wannier functions (valid for disentanglement).
+        ! Without this, input_proj is allocated at size num_wann and overflows.
+        call w90_readwrite_get_projections(settings, num_proj, atom_data, num_wann, proj_input, &
+                                           recip_lattice, .true., spinors, bohr, stdout, error, comm)
+        if (allocated(error)) return
         call w90_readwrite_get_projections(settings, num_proj, atom_data, num_wann, proj_input, &
                                            recip_lattice, .false., spinors, bohr, stdout, error, comm)
         if (allocated(error)) return

--- a/test-suite/CMakeLists.txt
+++ b/test-suite/CMakeLists.txt
@@ -142,6 +142,7 @@ endif ()
 if (WANNIER90_MPI)
 	# These tests require MPI interface
 	list(APPEND functional_tests
+			library-mode-test-proj-overflow
 			library-mode-test
 			library-mode-test-projections
 	)

--- a/test-suite/library-mode-test-proj-overflow/CMakeLists.txt
+++ b/test-suite/library-mode-test-proj-overflow/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.25...3.29)
+project(library_mode_test_proj_overflow LANGUAGES Fortran)
+
+find_package(Wannier90 REQUIRED)
+find_package(MPI REQUIRED COMPONENTS Fortran)
+
+add_executable(proj_overflow proj_overflow.f90)
+target_link_libraries(proj_overflow PRIVATE Wannier90::wannier90 MPI::MPI_Fortran)
+
+enable_testing()
+add_test(NAME run_proj_overflow
+        COMMAND $<TARGET_FILE:proj_overflow>
+)

--- a/test-suite/library-mode-test-proj-overflow/proj_overflow.f90
+++ b/test-suite/library-mode-test-proj-overflow/proj_overflow.f90
@@ -1,0 +1,62 @@
+program proj_overflow
+  use mpi
+  use w90_library
+
+  implicit none
+
+  type(lib_common_type) :: w90
+  integer :: ierr, stdout, stderr
+  integer :: num_proj
+  integer :: mp_grid(3)
+  integer :: l(8), m(8), s(8), rad(8)
+  real(kind=8) :: kpoints(3, 1), unit_cell(3, 3)
+  real(kind=8) :: atoms_frac(3, 1)
+  real(kind=8) :: site(3, 8), x(3, 8), z(3, 8), sqa(3, 8), zona(8)
+  character(len=2) :: symbols(1)
+
+  mp_grid = (/1, 1, 1/)
+  kpoints(:, 1) = (/0.0d0, 0.0d0, 0.0d0/)
+  unit_cell = 0.0d0
+  unit_cell(1, 1) = 10.0d0
+  unit_cell(2, 2) = 10.0d0
+  unit_cell(3, 3) = 10.0d0
+  atoms_frac(:, 1) = (/0.25d0, 0.25d0, 0.25d0/)
+  symbols(1) = 'Bi'
+
+  call MPI_Init(ierr)
+  call w90_get_fortran_stdout(stdout)
+  call w90_get_fortran_stderr(stderr)
+
+  call w90_set_comm(w90, MPI_COMM_WORLD)
+  call w90_set_option(w90, 'num_bands', 4)
+  call w90_set_option(w90, 'num_wann', 2)
+  call w90_set_option(w90, 'mp_grid', mp_grid)
+  call w90_set_option(w90, 'kpoints', kpoints)
+  call w90_set_option(w90, 'unit_cell_cart', unit_cell)
+  call w90_set_option(w90, 'symbols', symbols)
+  call w90_set_option(w90, 'atoms_frac', atoms_frac)
+  call w90_set_option(w90, 'projections', 'Bi:s,p')
+
+  call w90_input_setopt(w90, 'proj_overflow', stdout, stderr, ierr)
+  if (ierr /= 0) then
+    write (stderr, '(a,i0)') 'w90_input_setopt failed with ierr=', ierr
+    call MPI_Finalize(ierr)
+    stop 1
+  end if
+
+  num_proj = size(l)
+  call w90_get_proj(w90, num_proj, site, l, m, s, rad, x, z, sqa, zona, stdout, stderr, ierr)
+  if (ierr /= 0) then
+    write (stderr, '(a,i0)') 'w90_get_proj failed with ierr=', ierr
+    call MPI_Finalize(ierr)
+    stop 1
+  end if
+
+  if (num_proj /= 4) then
+    write (stderr, '(a,i0,a)') 'Expected 4 projections, got ', num_proj, '.'
+    call MPI_Finalize(ierr)
+    stop 1
+  end if
+
+  call MPI_Finalize(ierr)
+end program proj_overflow


### PR DESCRIPTION
The library interface called get_projections(lcount=.false.) directly, allocating input_proj at size num_wann.  When the projections block defines more functions than num_wann (valid for disentanglement), the fill loop writes beyond the array bounds.

Add the counting pass (lcount=.true.) before the fill pass so that num_proj is updated to the actual projection count before input_proj is allocated.

This MR was made with the help of AI, its porpose is to show more clearly the bug and propose a fix.
However, I don't know enough about the codebase to judge whether this is the best way to fix the problem