### PR TITLE
Fix uninitialized unit numbers in postw90 file opens

### DIFF
--- a/src/postw90/get_oper.F90
+++ b/src/postw90/get_oper.F90
@@ -1220,7 +1220,7 @@ contains
         write (stdout, '(a)') trim(header)
         read (uHu_in, *, err=106, end=106) nb_tmp, nkp_tmp, nntot_tmp
       else
-        open (unit=uHu_in, file=trim(seedname)//".uHu", form='unformatted', &
+        open (newunit=uHu_in, file=trim(seedname)//".uHu", form='unformatted', &
               status='old', action='read', err=105)
         write (stdout, '(/a)', advance='no') &
           ' Reading uHu overlaps from '//trim(seedname)//'.uHu in get_CC_R: '
@@ -1736,7 +1736,7 @@ contains
         write (stdout, '(a)') trim(header)
         read (spn_in, *, err=110, end=110) nb_tmp, nkp_tmp
       else
-        open (unit=spn_in, file=trim(seedname)//'.spn', form='unformatted', &
+        open (newunit=spn_in, file=trim(seedname)//'.spn', form='unformatted', &
               status='old', err=109)
         write (stdout, '(/a)', advance='no') &
           ' Reading spin matrices from '//trim(seedname)//'.spn in get_SS_R : '
@@ -1973,7 +1973,7 @@ contains
         write (stdout, '(a)') trim(header)
         read (spn_in, *, err=110, end=110) nb_tmp, nkp_tmp
       else
-        open (unit=spn_in, file=trim(seedname)//'.spn', form='unformatted', &
+        open (newunit=spn_in, file=trim(seedname)//'.spn', form='unformatted', &
               status='old', err=109)
         write (stdout, '(/a)', advance='no') &
           ' Reading spin matrices from '//trim(seedname)//'.spn in get_SHC_R : '
@@ -2371,7 +2371,7 @@ contains
         write (stdout, '(a)') trim(header)
         read (spn_in, *, err=110, end=110) nb_tmp, nkp_tmp
       else
-        open (unit=spn_in, file=trim(seedname)//'.spn', form='unformatted', &
+        open (newunit=spn_in, file=trim(seedname)//'.spn', form='unformatted', &
               status='old', err=109)
         write (stdout, '(/a)', advance='no') &
           ' Reading spin matrices from '//trim(seedname)//'.spn in get_SH_R : '

--- a/src/postw90/kslice.F90
+++ b/src/postw90/kslice.F90
@@ -839,7 +839,7 @@ contains
         elseif (plot_fermi_lines) then
           filename = trim(seedname)//'-kslice-shc'//'+fermi_lines.py'
           write (stdout, '(/,3x,a)') filename
-          open (scriptunit, file=filename, form='formatted')
+          open (newunit=scriptunit, file=filename, form='formatted')
         end if
         write (scriptunit, '(a)') "# uncomment these two lines if you are " &
           //"running in non-GUI environment"


### PR DESCRIPTION
## Summary

Several `open()` callsuse `open(unit=var, ...)` with un-initialized unit variable. One should use `open(newunit=var, ...)` which does the initialization. This PR changes a few remaining `unit=` to `newunit=`.

## How it surfaced

While debugging an unrelated issue I ran `./run_tests --category=default` and found `testpostw90_fe_morb_transl_inv_higher` aborting with "Problem opening input file Fe.uHu". Tracing the open at `get_oper.F90:1199` showed the `unit=` / `newunit=` asymmetry between the formatted and unformatted branches. A grep for the same pattern turned up the four additional sites listed above.

## Test plan

- [x] `./run_tests --category=default` → 91/91 pass with this PR. Previously `testpostw90_fe_morb_transl_inv_higher` hit the uHu open failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)