### PR TITLE
Propagate staticlib target from top level Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ wannier:
 	$(MAKE) -C src/obj ../$@
 
 staticlib:
-	$(MAKE) -C src/obj
+	$(MAKE) -C src/obj staticlib
 
 dynlib:
 	$(MAKE) -C src/obj dynlib


### PR DESCRIPTION
This fixes the case of a requested `staticlib` GNU Make target not being propagated. Without the specified target, the behaviour is to default to the first target in `src/obj/Makefile`, which at time of writing is `wannier`.