### PR TITLE
Make CODATA documentation match the code default

### DIFF
--- a/README.install
+++ b/README.install
@@ -303,6 +303,12 @@ Flags
 * CODATA2010
   Use physical constants from 2010 version of CODATA tables
   (http://physics.nist.gov/cuu/Constants/index.html)
+* CODATA2018
+  Use physical constants from 2018 version of CODATA tables
+  (http://physics.nist.gov/cuu/Constants/index.html)
+* CODATA2022
+  Use physical constants from 2022 version of CODATA tables
+  (http://physics.nist.gov/cuu/Constants/index.html)
 * USE_WANNIER90_V1_BOHR
   Use the value of the bohr radius (expressed in angstrom) that
   was adopted in versions 1.x of the Wannier90 code, instead of

--- a/src/constants.F90
+++ b/src/constants.F90
@@ -38,8 +38,9 @@ module w90_constants
   !!
   !! Values of the fundamental constants are taken from
   !! http://physics.nist.gov/cuu/Constants/index.html
-  !! By default CODATA2006 is used (CODATA2010/18/22 can be selected
-  !! using an appropriate compile-time flag (see INSTALL guide)
+  !! By default CODATA2006 is used. CODATA2010, CODATA2018 or CODATA2022
+  !! can be selected with the corresponding preprocessor flag
+  !! (see README.install)
 
   implicit none
 


### PR DESCRIPTION
Fixes #429.

`src/constants.F90` defaults to CODATA 2006 when no `CODATA*` preprocessor flag is set:

```fortran
#ifndef CODATA2022
#ifndef CODATA2018
#ifndef CODATA2006
#ifndef CODATA2010
#define CODATA2006
#endif
#endif
#endif
#endif
```

Since f63391dd the module also supports `CODATA2018` and `CODATA2022`, and the module header points to the install guide for the alternative flags. `README.install` however listed only `CODATA2006` and `CODATA2010`, so the header referenced flags the install guide did not document.

Changes (documentation only, no constant values touched):

- `README.install`: add `CODATA2018` and `CODATA2022` to the flags list, matching the existing entry format. `CODATA2006` keeps its "default" note, which matches the code.
- `src/constants.F90`: name the three alternative flags explicitly in the module header, point to `README.install`, and fix unbalanced parentheses.

Switching the default to CODATA 2022 is a separate change, tracked in #562.

## Verification

Default selection probe (program printing `constants_version_str1` from `w90_constants`):

```
$ gfortran -cpp src/constants.F90 codata_probe.f90 -o codata_probe && ./codata_probe
-> Using CODATA 2006 constant values
$ gfortran -cpp -DCODATA2010 src/constants.F90 codata_probe.f90 -o codata_probe2010 && ./codata_probe2010
-> Using CODATA 2010 constant values
```

Documentation before (grep -n CODATA, doc lines only):

```
src/constants.F90:41:  !! By default CODATA2006 is used (CODATA2010/18/22 can be selected
src/constants.F90:42:  !! using an appropriate compile-time flag (see INSTALL guide)
README.install:299:* CODATA2006
README.install:303:* CODATA2010
```

(no `CODATA2018` or `CODATA2022` entries in README.install)

Documentation after:

```
src/constants.F90:41:  !! By default CODATA2006 is used. CODATA2010, CODATA2018 or CODATA2022
src/constants.F90:42:  !! can be selected with the corresponding preprocessor flag
src/constants.F90:43:  !! (see README.install)
README.install:299:* CODATA2006
README.install:303:* CODATA2010
README.install:306:* CODATA2018
README.install:309:* CODATA2022
```

The edited module still compiles with and without flags:

```
$ gfortran -c -cpp src/constants.F90 -o /tmp/constants_default.o   # OK
$ gfortran -c -cpp -DCODATA2022 src/constants.F90 -o /tmp/constants_2022.o   # OK
```
