### PR TITLE
fix(cmake): gate C interface behind WANNIER90_WITH_C

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ endif ()
 
 option(WANNIER90_MPI "Wannier90: Build with MPI support" OFF)
 option(WANNIER90_MPIH "Wannier90: Build MPI support using the mpi.h header" OFF)
+option(WANNIER90_WITH_C "Wannier90: Build the C interface" OFF)
 option(WANNIER90_SHARED_LIBS "Wannier90: Build library as a shared library" ${PROJECT_IS_TOP_LEVEL})
 option(WANNIER90_INSTALL "Wannier90: Install files" ${PROJECT_IS_TOP_LEVEL})
 option(WANNIER90_TEST "Wannier90: Build test-suite" ${PROJECT_IS_TOP_LEVEL})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,7 +26,6 @@
 
 ## Source files definitions
 target_sources(Wannier90_lib PRIVATE
-		c_interface.F90
 		comms.F90
 		constants.F90
 		disentangle.F90
@@ -44,12 +43,17 @@ target_sources(Wannier90_lib PRIVATE
 		transport.F90
 		types.F90
 		utility.F90
-		wannier90.c
 		wannier90_readwrite.F90
 		wannier90_types.F90
 		wannierise.F90
 		ws_distance.F90
 		)
+if (WANNIER90_WITH_C)
+	target_sources(Wannier90_lib PRIVATE
+			c_interface.F90
+			wannier90.c
+			)
+endif ()
 target_sources(Wannier90_exe PRIVATE
 		wannier_prog.F90
 		)
@@ -66,9 +70,13 @@ target_include_directories(Wannier90_lib PUBLIC
 		"$<BUILD_INTERFACE:${CMAKE_Fortran_MODULE_DIRECTORY}>"
 		"$<INSTALL_INTERFACE:${CMAKE_INSTALL_MODULEDIR}/Wannier90>"
 )
+if (WANNIER90_WITH_C)
+	target_sources(Wannier90_lib
+			INTERFACE FILE_SET wannier90_C_Headers TYPE HEADERS FILES
+			wannier90.h
+	)
+endif ()
 target_sources(Wannier90_lib
-		INTERFACE FILE_SET wannier90_C_Headers TYPE HEADERS FILES
-		wannier90.h
 		INTERFACE FILE_SET wannier90_Fortran_Headers TYPE HEADERS BASE_DIRS ${CMAKE_Fortran_MODULE_DIRECTORY} FILES
 		${CMAKE_Fortran_MODULE_DIRECTORY}/w90_library.mod
 )
@@ -97,9 +105,16 @@ add_subdirectory(postw90)
 
 ## Installs
 if (WANNIER90_INSTALL)
-	install(TARGETS Wannier90_lib Wannier90_exe
-			EXPORT Wannier90Targets
-			FILE_SET wannier90_C_Headers
-			FILE_SET wannier90_Fortran_Headers DESTINATION ${CMAKE_INSTALL_MODULEDIR}/Wannier90
-			)
+	if (WANNIER90_WITH_C)
+		install(TARGETS Wannier90_lib Wannier90_exe
+				EXPORT Wannier90Targets
+				FILE_SET wannier90_C_Headers
+				FILE_SET wannier90_Fortran_Headers DESTINATION ${CMAKE_INSTALL_MODULEDIR}/Wannier90
+				)
+	else ()
+		install(TARGETS Wannier90_lib Wannier90_exe
+				EXPORT Wannier90Targets
+				FILE_SET wannier90_Fortran_Headers DESTINATION ${CMAKE_INSTALL_MODULEDIR}/Wannier90
+				)
+	endif ()
 endif ()


### PR DESCRIPTION
`README.install` mentions using `-DWANNIER90_WITH_C=ON` to build the C interface, but the option does not appear to be defined and used to gate inclusion of the C interface sources and install of the C interface.