### PR TITLE
remove "_mpi" suffix from library name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.25...3.29)
 
 list(APPEND CMAKE_MESSAGE_CONTEXT Wannier90)
 project(Wannier90
-		VERSION 4.0.0
+		VERSION 4.0.3
 		DESCRIPTION "Compute maximally-localised Wannier functions."
 		HOMEPAGE_URL https://www.wannier90.org
 		LANGUAGES Fortran C
@@ -31,10 +31,8 @@ option(WANNIER90_SHARED_LIBS "Wannier90: Build library as a shared library" ${PR
 option(WANNIER90_INSTALL "Wannier90: Install files" ${PROJECT_IS_TOP_LEVEL})
 option(WANNIER90_TEST "Wannier90: Build test-suite" ${PROJECT_IS_TOP_LEVEL})
 
+# the library name is the same for MPI and serial builds
 set(WANNIER90_LIBRARY_NAME wannier90)
-if (WANNIER90_MPI)
-	set(WANNIER90_LIBRARY_NAME wannier90_mpi)
-endif ()
 
 #[=============================================================================[
 #                            Project configuration                            #

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ clean:
 
 # Note: .x.dSYM are directories (hence the -r option to rm) and are only created on macOS (when compiling with certain flags, e.g. debug), so they are not always present
 veryclean: clean
-	cd $(ROOTDIR) && rm -rf wannier90.x postw90.x w90chk2chk.x w90spn2spn.x libwannier90.{a,so.4} libwannier90_mpi.{a,so.4} *.{gcda,gcno} *.x.dSYM
+	cd $(ROOTDIR) && rm -rf wannier90.x postw90.x w90chk2chk.x w90spn2spn.x libwannier90.{a,so.4} libwannier90.{a,so.4} *.{gcda,gcno} *.x.dSYM
 	cd $(ROOTDIR)/test-suite && ./clean_tests -i
 
 thedoc:

--- a/Makefile.header
+++ b/Makefile.header
@@ -43,15 +43,13 @@ COMPILER = $(TEMP2)
 ## everything with -fPIC usually, on 64bit systems
 SHAREDLIBFLAGS ?=-shared -Wl,-soname,libwannier90.so.4 -fPIC
 
-## Define the filename
+## Define the filename: the file name is the same in MPI and serial
 ifdef USEMPI
-  LIBSUFFIX=_mpi
   LIBDESCRIPTION = Compute maximally-localised Wannier functions (MPI version)
 else
-  LIBSUFFIX=
   LIBDESCRIPTION = Compute maximally-localised Wannier functions
 endif
 
-DYNLIBBASE = wannier90$(LIBSUFFIX)
+DYNLIBBASE = wannier90
 STATICLIBRARY = lib$(DYNLIBBASE).a
 DYNLIBRARY = lib$(DYNLIBBASE).so.4

--- a/test-suite/library-mode-test/demo.F90
+++ b/test-suite/library-mode-test/demo.F90
@@ -47,7 +47,7 @@ program ok
   integer :: i, ib, ic, ik, nkl
   integer :: ika, ikb, ikc, nkabc(3)
   integer :: mpisize, mpirank
-  integer :: nb, nk, nn, nw
+  integer :: nb, nk, nn, nw, nkloc
   real(8), allocatable :: eval(:, :), kpt(:, :)
   real(8) :: uccart(3, 3) ! cartesian unit cell
   type(lib_common_type) :: w90main
@@ -104,6 +104,7 @@ program ok
   do i = 1, nk
     distk(i) = (i - 1)/nkl ! contiguous blocks with potentially fewer processes on last rank
   end do
+  nkloc = count(distk(:) == mpirank)
 
   ! wannier interface starts
   ! stdout/err
@@ -137,7 +138,7 @@ program ok
   call w90_get_nn(w90main, nn, stdout, stderr, ierr)
   allocate (nnkp(nk, nn))
   call w90_get_nnkp(w90main, nnkp, stdout, stderr, ierr)
-  allocate (m_matrix(nb, nb, nn, nk))
+  allocate (m_matrix(nb, nb, nn, nkloc))
   allocate (u_matrix_opt(nb, nw, nk))
   call w90_set_m_local(w90main, m_matrix) ! m_matrix_local_orig
   call w90_set_u_opt(w90main, u_matrix_opt)


### PR DESCRIPTION
- serial and parallel compilations of the library have the same name
- update cmake .so version to 4.0.3

fixes #674 