### PR TITLE
Fix sign of r-bar in the documented transl_inv_full formula (postw90params.md)

### DIFF
--- a/docs/docs/user_guide/postw90/postw90params.md
+++ b/docs/docs/user_guide/postw90/postw90params.md
@@ -477,7 +477,11 @@ c_{\mathbf{b}} \mathbf{b} \, e^{i\mathbf{b} \cdot
 $$
 
 where $\bar{\mathbf{r}}_{ij;\mathbf{R}} =
-(\mathbf{r}_i + \mathbf{r}_j + \mathbf{R}) / 2$.
+(\mathbf{r}_i + \mathbf{r}_j - \mathbf{R}) / 2$, consistent with the
+$e^{-i\mathbf{k} \cdot \mathbf{R}}$ convention used above. Equivalently,
+$\bar{\mathbf{r}}_{ij;\mathbf{R}} = \mathbf{c}_{ij;\mathbf{R}} - \mathbf{R}$,
+where $\mathbf{c}_{ij;\mathbf{R}} = (\mathbf{r}_i + \mathbf{r}_j + \mathbf{R}) / 2$
+is the midpoint between the centres of $w_{i\mathbf{0}}$ and $w_{j\mathbf{R}}$.
 The needed wannier centres are computed using
 the Marzari-Vanderbilt formula.
 


### PR DESCRIPTION
## Problem

The `transl_inv_full` documentation gives the reference point as

$$\bar{\mathbf{r}}_{ij;\mathbf{R}} = (\mathbf{r}_i + \mathbf{r}_j + \mathbf{R})/2 ,$$

but `get_AA_R` implements the opposite sign of $\mathbf{R}$. The code is right and the docs are
wrong. Anyone implementing the documented formula — in a downstream code, or when extending
`transl_inv_full` to `wannier90.x`'s `_r.dat`/`_tb.dat`, which do not support it yet — gets a
result **worse than not applying the correction at all** (table below).

`src/postw90/get_oper.F90` applies the phase in two stages:

| stage | line (`5fc9c233`) | factor |
|---|---|---|
| k-space, `r0 = (r_i + r_j)/2` | [`get_oper.F90:668-671`](https://github.com/wannier-developers/wannier90/blob/5fc9c2331df52adbba76a0e9c1ff258522f553c2/src/postw90/get_oper.F90#L668-L671) | $e^{+i\mathbf{b}\cdot(\mathbf{r}_i+\mathbf{r}_j)/2}$ |
| R-space, `crvec_pw90` | [`get_oper.F90:708-713`](https://github.com/wannier-developers/wannier90/blob/5fc9c2331df52adbba76a0e9c1ff258522f553c2/src/postw90/get_oper.F90#L708-L713) | $e^{-i\mathbf{b}\cdot\mathbf{R}/2}$ |

i.e. $\bar{\mathbf{r}}_{ij;\mathbf{R}} = (\mathbf{r}_i + \mathbf{r}_j - \mathbf{R})/2$. Same
pattern in `get_BB_R` (`:986-989`, `:1034-1038`) and the other `transl_inv_full` operators.

## Fix

`docs/docs/user_guide/postw90/postw90params.md` — flip the sign and state the convention:

- before: $\bar{\mathbf{r}}_{ij;\mathbf{R}} = (\mathbf{r}_i + \mathbf{r}_j + \mathbf{R})/2$
- after: &nbsp;$\bar{\mathbf{r}}_{ij;\mathbf{R}} = (\mathbf{r}_i + \mathbf{r}_j - \mathbf{R})/2 = \mathbf{c}_{ij;\mathbf{R}} - \mathbf{R}$

with $\mathbf{c}_{ij;\mathbf{R}} = (\mathbf{r}_i + \mathbf{r}_j + \mathbf{R})/2$ the midpoint
between the centres of $w_{i\mathbf{0}}$ and $w_{j\mathbf{R}}$. Keeping $\mathbf{c}$ in the text
makes it clear that the physical midpoint is unchanged; what shifts is the frame, because
$M^{(\mathbf{k},\mathbf{b})}_{ij}$ Fourier-transforms into the frame where the ket sits in the home
cell.

Derivation. With Wannier90's $|w_{j\mathbf{R}}\rangle = N^{-1}\sum_\mathbf{k} e^{-i\mathbf{k}\cdot\mathbf{R}}|\psi_{j\mathbf{k}}\rangle$ — the same $e^{-i\mathbf{k}\cdot\mathbf{R}}$ that appears in the formula itself —

$$\frac{1}{N}\sum_\mathbf{k} e^{-i\mathbf{k}\cdot\mathbf{R}} M^{(\mathbf{k},\mathbf{b})}_{ij}
= e^{+i\mathbf{b}\cdot\mathbf{R}}\,\langle w_{i\mathbf{0}}|e^{-i\mathbf{b}\cdot\hat{\mathbf{r}}}|w_{j\mathbf{R}}\rangle ,$$

and the overlap density $w^*_{i\mathbf{0}}w_{j\mathbf{R}}$ is centred on $\mathbf{c}_{ij;\mathbf{R}}$.
Cancelling both oscillations requires $e^{i\mathbf{b}\cdot(\mathbf{c}_{ij;\mathbf{R}}-\mathbf{R})}$.

No source change; `transl_inv_full` results are unaffected.

## Test

Docs-only, so verified against the physics rather than the suite.

**1. 1D model, exact reference.** Orthonormal Wannier functions built by Löwdin-orthogonalising a
periodised Gaussian on a 10-cell chain (overlaps $\langle w_0|w_R\rangle$ = 1 and $<2\times10^{-16}$),
so $\langle w_0|\hat{x}|w_R\rangle$ is known exactly. Error of each estimator, single b-shell:

| $R/a$ | exact | naive | $\bar{r}=(r_i+r_j-\mathbf{R})/2$ | $\bar{r}=(r_i+r_j+\mathbf{R})/2$ (as documented) |
|---|---|---|---|---|
| 0 | 5.000000 | −5.0e+00 | **5.8e-07** | 5.8e-07 |
| 1 | 0.000099 | +1.2e-02 | **−9.9e-05** | −2.3e-02 |
| 2 | −0.000235 | −1.6e-02 | **+2.4e-04** | +2.7e-02 |
| 3 | 0.000362 | +1.3e-02 | **−3.6e-04** | −1.6e-02 |

(columns 3–5 are errors vs. exact). The documented sign is ~2× worse than the naive formula; the
implemented sign is ~50× better.

**2. Against the shipped implementation.** `testw90_example03` (silicon, 4×4×4), `transl_inv_full = true`,
`use_ws_distance = .false.`: a `_r.dat`-format dump of postw90's `AA_R` agrees with an independent
`wannier90.x`-side implementation of the *code's* sign on all 5952 $(\mathbf{R},i,j)$ elements to
7.1e-7 Å — the `F12.6` write precision. The documented sign does not reproduce it.
