### PR TITLE
Fix segfault in io_commandline

### DIFF
--- a/src/io.F90
+++ b/src/io.F90
@@ -39,7 +39,7 @@ module w90_io
 
   private
 
-  character(len=10), parameter, public :: w90_version = '4.0.1 ' !! Label for this version of wannier90
+  character(len=10), parameter, public :: w90_version = '4.0.3 ' !! Label for this version of wannier90
 
   public :: io_stopwatch_start
   public :: io_stopwatch_stop
@@ -248,13 +248,6 @@ contains
       end if
     end if
 
-    ! If on the command line the whole seedname.win was passed, I strip the last ".win"
-    if (len(trim(seedname)) .ge. 5) then
-      if (seedname(len(trim(seedname)) - 4 + 1:) .eq. ".win") then
-        seedname = seedname(:len(trim(seedname)) - 4)
-      end if
-    end if
-
     if (print_help) then
       if (prog == 'wannier90') then
         write (6, '(a)') 'Wannier90: The Maximally Localised Wannier Function Code'
@@ -285,6 +278,13 @@ contains
         write (6, '(a,a)') 'Postw90: ', trim(w90_version)
       end if
       stop
+    end if
+
+    ! If on the command line the whole seedname.win was passed, I strip the last ".win"
+    if (len(trim(seedname)) .ge. 5) then
+      if (seedname(len(trim(seedname)) - 4 + 1:) .eq. ".win") then
+        seedname = seedname(:len(trim(seedname)) - 4)
+      end if
     end if
 
   end subroutine io_commandline


### PR DESCRIPTION
io_commandline stripped a trailing ".win" from seedname before handling the -h/-v/no-argument cases. On all of those cases, seedname is never assigned, so trim(seedname) was evaluated on an unallocated allocatable, reading a potentially garbage descriptor length and resulting in a segfault.

This is undefined behaviour, so the symptom is platform-dependent: on many systems or compilers probably the descriptor happens to hold a benign length and the code doesn't crash.
However, on arm64 macOS (with gfortran, -O2, at least on my laptop) it segfaults immediately (even just invoking `wannier90.x` without parameters).

By moving the ".win" stripping after the print_help and print_version blocks, both of which stop, seedname is only trimmed when it has actually been assigned.

Note: I also bumped the version string (it was incorrectly still at 4.0.1, I bumped directly at 4.0.3 as this is the next planned release)