### PR TITLE
Initialise off-diagonal elements of au_matrix when use_bloch_phases is true.

### DIFF
--- a/src/overlap.F90
+++ b/src/overlap.F90
@@ -949,16 +949,9 @@ contains
         !
         ! SINGULAR VALUE DECOMPOSITION
         !
-        write(77,*) 'pre - nkp: ',nkp
-        write(77,*) u_matrix(:, :, nkp)
-        write(77,*)
-
 
         call zgesvd('A', 'A', num_bands, num_bands, u_matrix(1, 1, nkp), num_bands, svals, cz, &
                     num_bands, cvdag, num_bands, cwork, 4*num_bands, rwork, info)
-        write(77,*) 'nkp: ',nkp
-        write(77,*) u_matrix(:, :, nkp)
-        write(77,*)
         if (info .ne. 0) then
           write (stdout, *) ' ERROR: IN ZGESVD IN overlap_project'
           write (stdout, *) ' K-POINT NKP=', nkp, ' INFO=', info

--- a/src/overlap.F90
+++ b/src/overlap.F90
@@ -377,7 +377,7 @@ contains
       !if (allocated(error)) return
 
     else
-
+      au_matrix = cmplx_0
       do n = 1, num_kpts
         do m = 1, num_wann
           au_matrix(m, m, n) = cmplx_1
@@ -949,8 +949,16 @@ contains
         !
         ! SINGULAR VALUE DECOMPOSITION
         !
+        write(77,*) 'pre - nkp: ',nkp
+        write(77,*) u_matrix(:, :, nkp)
+        write(77,*)
+
+
         call zgesvd('A', 'A', num_bands, num_bands, u_matrix(1, 1, nkp), num_bands, svals, cz, &
                     num_bands, cvdag, num_bands, cwork, 4*num_bands, rwork, info)
+        write(77,*) 'nkp: ',nkp
+        write(77,*) u_matrix(:, :, nkp)
+        write(77,*)
         if (info .ne. 0) then
           write (stdout, *) ' ERROR: IN ZGESVD IN overlap_project'
           write (stdout, *) ' K-POINT NKP=', nkp, ' INFO=', info


### PR DESCRIPTION
This avoid numerical errors and a lapack failure.
This was an error introduced in 4.0.x as previously this array was initialised on allocation.