### PR TITLE
Build and publish the developer documentation (FORD) automatically

### DIFF
--- a/.github/workflows/autodoc.yaml
+++ b/.github/workflows/autodoc.yaml
@@ -1,0 +1,46 @@
+name: 📗 autodoc
+
+# Publishes the FORD developer documentation to GitHub Pages on every push to
+# develop, and on demand.
+#
+# Pull requests do not deploy: they are built as a regression check by the
+# 📗 autodoc job in ci.yaml, which calls the same reusable build workflow.
+#
+# One-time manual setup is required before the deploy job can succeed: repo
+# Settings -> Pages -> Build and deployment -> Source = "GitHub Actions", and
+# the github-pages environment must allow deployment from develop.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ develop ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: 📗 autodoc
+    uses: ./.github/workflows/step_autodoc.yaml
+    with:
+      upload: true
+
+  deploy:
+    name: 🚀 deploy
+    needs: [ build ]
+    runs-on: ubuntu-latest
+    # Elevated beyond the read-only default, which is why deployment lives in
+    # this workflow rather than in ci.yaml.
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,6 +43,8 @@ jobs:
     name: 📗 autodoc
     needs: [ pre-commit ]
     uses: ./.github/workflows/step_autodoc.yaml
+    with:
+      graphs: false
 
   pass:
     name: ✅ Pass

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,9 +39,14 @@ jobs:
     needs: [ pre-commit ]
     uses: ./.github/workflows/step_docs.yaml
 
+  autodoc:
+    name: 📗 autodoc
+    needs: [ pre-commit ]
+    uses: ./.github/workflows/step_autodoc.yaml
+
   pass:
     name: ✅ Pass
-    needs: [ pre-commit, tests, tests-makefile, docs ]
+    needs: [ pre-commit, tests, tests-makefile, docs, autodoc ]
     runs-on: ubuntu-latest
     steps:
       - name: Check all CI jobs

--- a/.github/workflows/step_autodoc.yaml
+++ b/.github/workflows/step_autodoc.yaml
@@ -1,0 +1,76 @@
+name: 📗 test-autodoc
+
+# Builds the FORD developer documentation from autodoc/project.md.
+#
+# Reusable: called by ci.yaml as a regression check on every pull request, and
+# by autodoc.yaml on a push to develop, where the built site is also uploaded
+# as a Pages artifact for the deploy job in that workflow to publish.
+
+on:
+  workflow_call:
+    inputs:
+      upload:
+        type: boolean
+        default: false
+        description: Upload the built site as a GitHub Pages artifact
+
+permissions:
+  contents: read
+
+jobs:
+  autodoc:
+    name: Build FORD documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          # pinned rather than "3.x", so a new Python release cannot break the
+          # build independently of the FORD version pinned below
+          python-version: "3.11"
+          cache: "pip"
+
+      # Required by `graph: true` in project.md. Present on ubuntu-latest today,
+      # but installed explicitly so a runner image change cannot silently turn
+      # the call and dependency graphs off.
+      - name: Install graphviz
+        run: sudo apt-get update && sudo apt-get install -y graphviz
+
+      # NOTE: FORD pins `markdown ~= 3.4` while mkdocs-material in
+      # docs/requirements.txt requires `markdown >= 3.6`. The two cannot be
+      # installed together, so this job must keep its own environment and must
+      # not be merged with the 📘 test-docs job.
+      #
+      # The version is pinned deliberately. FORD releases a few times a year;
+      # bump this by hand so a regression shows up in a pull request build
+      # rather than in a deployment.
+      - name: Install FORD
+        run: pip install "ford==7.0.13"
+
+      - name: Build documentation
+        working-directory: ./autodoc
+        run: ford project.md 2>&1 | tee ford.log
+
+      # FORD exits 0 even when it fails to parse a source file and drops it from
+      # the output. That is how the whole w90_types module went missing from the
+      # published documentation unnoticed, so treat it as a build failure.
+      - name: Fail on parse errors
+        working-directory: ./autodoc
+        run: |
+          if grep -q "Error parsing" ford.log; then
+            echo "::error::FORD failed to parse one or more source files, which are silently missing from the documentation:"
+            grep -B2 -A2 "Error parsing" ford.log
+            exit 1
+          fi
+
+      # Non-fatal: keeps other regressions visible in the log without blocking.
+      - name: Report remaining warnings
+        working-directory: ./autodoc
+        continue-on-error: true
+        run: grep -i "warning" ford.log || echo "No warnings."
+
+      - name: Upload Pages artifact
+        if: inputs.upload
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./autodoc/build

--- a/.github/workflows/step_autodoc.yaml
+++ b/.github/workflows/step_autodoc.yaml
@@ -13,6 +13,10 @@ on:
         type: boolean
         default: false
         description: Upload the built site as a GitHub Pages artifact
+      graphs:
+        type: boolean
+        default: true
+        description: Draw the call and dependency graphs
 
 permissions:
   contents: read
@@ -47,9 +51,19 @@ jobs:
       - name: Install FORD
         run: pip install "ford==7.0.13"
 
+      # Drawing the graphs takes about ten times as long as the rest of the
+      # build, so the pull request check skips them. project.md always asks for
+      # them, so the published documentation is unaffected.
       - name: Build documentation
         working-directory: ./autodoc
-        run: ford project.md 2>&1 | tee ford.log
+        env:
+          GRAPHS: ${{ inputs.graphs }}
+        run: |
+          if [ "$GRAPHS" = "true" ]; then
+            ford project.md 2>&1 | tee ford.log
+          else
+            ford --config "graph = false" project.md 2>&1 | tee ford.log
+          fi
 
       # FORD exits 0 even when it fails to parse a source file and drops it from
       # the output. That is how the whole w90_types module went missing from the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ There are a number of different types of documentation associated with the distr
 * `/doc/user_guide/` is the main User Guide for the code, where new variables, input parameters, functionality and file formats should be described
 * `/doc/tutorial/` is the tutorial guide for the examples in /examples/ and should be updated whenever a new example is added
 * `/examples/README` provides a very brief description of each example and the associated functionality that it covers
-FORD annotations should be included in all code that is developed
+FORD annotations should be included in all code that is developed; the resulting documentation is published at <https://wannier-developers.github.io/wannier90/>
 
 ## Test suite
 A set of tests is provided with Wannier90, in the folder `test-suite`.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ things, that linking the dynamic library with your code does not impose the GPL 
 
 - [CONTRIBUTING.md](CONTRIBUTING.md) — coding style, documentation requirements, and how pull requests are handled
 - [`test-suite/README.md`](test-suite/README.md) — how to run the tests and how to add new ones
-- [Code overview](https://wannier90.readthedocs.io/en/latest/user_guide/wannier90/code_overview/) · [FORD source-code documentation](https://wannier.org/ford/index.html)
+- [Code overview](https://wannier90.readthedocs.io/en/latest/user_guide/wannier90/code_overview/) · [FORD source-code documentation](https://wannier-developers.github.io/wannier90/)
 - [CHANGELOG.md](CHANGELOG.md)
 
 ## How to cite

--- a/autodoc/README.txt
+++ b/autodoc/README.txt
@@ -1,9 +1,34 @@
 Wannier90 autodoc
 =================
 
-The auto-generated documentation is build using FORD (https://github.com/cmacmackin/ford/wiki).
+The auto-generated documentation is built using FORD
+(https://github.com/Fortran-FOSS-Programmers/ford), whose documentation is at
+https://forddocs.readthedocs.io.
 
-To create the documentation, install FORD and run
+The published result is at https://wannier-developers.github.io/wannier90/. It is
+built and deployed automatically by the GitHub Actions workflows in
+.github/workflows/ (step_autodoc.yaml and autodoc.yaml), so it does not normally
+need to be built by hand. The manual route below remains useful for previewing
+changes locally.
+
+Installing FORD
+---------------
+
+FORD must be installed in an environment SEPARATE from the one used for the
+MkDocs user documentation in docs/requirements.txt. FORD pins `markdown ~= 3.4`
+while mkdocs-material 9.7.7 requires `markdown >= 3.6`, so installing both
+together fails with a pip resolver conflict. Use a dedicated virtualenv:
+
+    python3 -m venv .venv-ford
+    .venv-ford/bin/pip install ford
+
+Graphviz must also be installed on the system, otherwise `graph: true` in
+project.md cannot generate the call and dependency graphs.
+
+Building locally
+----------------
+
+To create the documentation, run
 
     ford project.md
 

--- a/autodoc/fast.md
+++ b/autodoc/fast.md
@@ -6,7 +6,6 @@ project:          Wannier90
 author:           The Wannier90 Developer Group
 project_github:   https://github.com/wannier-developers/wannier90
 project_website:  http://wannier.org
-title:            Wannier90 developer documentation
 summary:          Wannier90 is a code that calculates maximally-localised Wannier functions.
 display:          public
                   protected

--- a/autodoc/project.md
+++ b/autodoc/project.md
@@ -6,7 +6,6 @@ project:          Wannier90
 author:           The Wannier90 Developer Group
 project_github:   https://github.com/wannier-developers/wannier90
 project_website:  http://wannier.org
-title:            Wannier90 developer documentation
 summary:          Wannier90 is a code that calculates maximally-localised Wannier functions.
 display:          public
                   protected

--- a/src/types.F90
+++ b/src/types.F90
@@ -64,7 +64,7 @@ module w90_types
     !!==================================================
     !! Contains physical information about the material being calculated.
     !!==================================================
-    integer :: num_valence_bands !**no sensibe default**
+    integer :: num_valence_bands ! **no sensible default**
     integer :: num_elec_per_state = 2 ! used in: wannierise and postw90 dos and boltzwann
     logical :: spinors = .false.  !are our WF spinors? !kmesh, plot, wannier_lib, postw90/gyrotropic
   end type w90_system_type

--- a/src/utility.F90
+++ b/src/utility.F90
@@ -946,10 +946,10 @@ contains
 
     ! arguments
     real(kind=dp) :: utility_wgauss, x
-    !! output: the value of the function
-    !! input: the argument of the function
+    !! *output*: the value of the function
+    !! *input*: the argument of the function
     integer :: n
-    !! input: the order of the function
+    !! *input*: the order of the function
 
     ! local variables
     real(kind=dp) :: a, hp, arg, hd, xp
@@ -1024,11 +1024,11 @@ contains
 
     ! arguments
     real(kind=dp) :: utility_w0gauss
-    !! output: the value of the function
+    !! *output*: the value of the function
     real(kind=dp), intent(in) :: x
-    !! input: the point where to compute the function
+    !! *input*: the point where to compute the function
     integer, intent(in) :: n
-    !! input: the order of the smearing function
+    !! *input*: the order of the smearing function
     type(w90_error_type), allocatable, intent(out) :: error
     type(w90_comm_type), intent(in) :: comm
 
@@ -1112,10 +1112,10 @@ contains
     type(w90_error_type), allocatable, intent(out) :: error
     real(kind=dp), intent(in) ::  x(:)
     real(kind=dp), allocatable  :: res(:), arg(:)
-    !! output: the value of the function
-    !! input: the point where to compute the function
+    !! *output*: the value of the function
+    !! *input*: the point where to compute the function
     integer :: n
-    !! input: the order of the smearing function
+    !! *input*: the order of the smearing function
     type(w90_comm_type), intent(in) :: comm
     integer :: ierr
 


### PR DESCRIPTION
The FORD developer documentation was built and uploaded by hand, and the
published copy had not been updated since 2020. It is now built by CI on every
pull request, and published on every push to develop at
https://wannier-developers.github.io/wannier90/

**Note:** on every PR, the graph (with graphviz) is not compiled, only the docs:
in this way, we catch any syntax error and report as a CI error, but we save a
lot of time: on a macOS laptop, building without a graph took 30 seconds, with graph
5 minutes and 30 seconds (11x slower).
On a merge on the main `develop` branch, the graph is instead built, so that
the published documentation has it.

Two comments in the source confused FORD. One stopped it reading
src/types.F90, so the whole w90_types module was missing from the
documentation; the other lost nine lines of text in src/utility.F90. Both are
fixed. FORD reports success even when it drops a file like this, so the build
now fails if anything was dropped.

README.md and CONTRIBUTING.md link to the new address, and the autodoc README
says how to build the documentation locally.

**Note:** After merging, one setting has to be changed by hand: Settings -> Pages ->
Source = "GitHub Actions". The old copy on wannier.org can then be removed.

Fixes #4 