### PR TITLE
Fix undefined output value in the parameter report

### DIFF
--- a/.github/workflows/step_test.yaml
+++ b/.github/workflows/step_test.yaml
@@ -80,3 +80,12 @@ jobs:
         with:
           workflowPreset: "${{ matrix.toolchain }}-ci"
         continue-on-error: ${{ matrix.experimental && inputs.mask-experimental}}
+      - name: Upload test work directory on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: >-
+            work-${{ matrix.os || 'fedora' }}-${{ matrix.toolchain }}-${{ matrix.mpi || 'serial' }}
+          path: cmake-build-ci-*/test-suite/tests/work/
+          retention-days: 7
+          if-no-files-found: warn

--- a/src/wannier90_readwrite.F90
+++ b/src/wannier90_readwrite.F90
@@ -1841,7 +1841,7 @@ contains
     logical, intent(in) :: spinors
 
     ! local variables
-    character(len=1) :: one_dim_axis
+    character(len=4) :: one_dim_axis
     integer :: i, nkp, loop, nat, nsp, bands_num_spec_points
     logical :: disentanglement
     real(kind=dp) :: ccentres_frac(3)
@@ -1850,6 +1850,11 @@ contains
 
     disentanglement = (num_bands > num_wann)
 
+    ! `one_dim_axis` is only meaningful when the system is treated as reduced-
+    ! dimensional, but it is printed unconditionally below (for any run with
+    ! transport enabled or iprint > 2). Without a default it would be written
+    ! while undefined whenever the input does not set `one_dim_axis`.
+    one_dim_axis = 'none'
     if (real_space_ham%one_dim_dir == 1) one_dim_axis = 'x'
     if (real_space_ham%one_dim_dir == 2) one_dim_axis = 'y'
     if (real_space_ham%one_dim_dir == 3) one_dim_axis = 'z'
@@ -2183,9 +2188,11 @@ contains
             write (stdout, '(1x,a46,10x,I8,13x,a1)') '|   Dimension of the system                  :', &
               real_space_ham%system_dim, '|'
             if (real_space_ham%system_dim .eq. 1) &
-              write (stdout, '(1x,a46,10x,a8,13x,a1)') '|   System extended in                       :', one_dim_axis, '|'
+              write (stdout, '(1x,a46,10x,a8,13x,a1)') '|   System extended in                       :', &
+              adjustr(one_dim_axis), '|'
             if (real_space_ham%system_dim .eq. 2) &
-              write (stdout, '(1x,a46,10x,a8,13x,a1)') '|   System confined in                       :', one_dim_axis, '|'
+              write (stdout, '(1x,a46,10x,a8,13x,a1)') '|   System confined in                       :', &
+              adjustr(one_dim_axis), '|'
             write (stdout, '(1x,a46,10x,F8.3,13x,a1)') '|   Hamiltonian cut-off value                :', &
               real_space_ham%hr_cutoff, '|'
             write (stdout, '(1x,a46,10x,F8.3,13x,a1)') '|   Hamiltonian cut-off distance             :', &
@@ -2248,7 +2255,8 @@ contains
         !
         write (stdout, '(1x,a46,10x,a8,13x,a1)') '|   Hamiltonian from external files          :', 'F', '|'
 
-        write (stdout, '(1x,a46,10x,a8,13x,a1)') '|   System extended in                       :', one_dim_axis, '|'
+        write (stdout, '(1x,a46,10x,a8,13x,a1)') '|   System extended in                       :', &
+          adjustr(one_dim_axis), '|'
         !
       end if
 

--- a/test-suite/tests/testw90_na_chain_gamma/test.yaml
+++ b/test-suite/tests/testw90_na_chain_gamma/test.yaml
@@ -1,6 +1,6 @@
 # testw90_na_chain_gamma
 
-description: "Silane, valence states, Gamma only"
+description: "Sodium chain, valence states, Gamma only"
 profile: wannier90_wout
 runs:
   - input: Na_chain.win


### PR DESCRIPTION
The "System extended in" line in the parameter report was printed without the
variable behind it ever being set, unless the input file specified a
one-dimensional axis. The line is printed whenever transport is enabled or the
output verbosity is above 2, so runs that did not set the axis wrote out
whatever happened to be in memory at the time.

This produced a stray non-text character in the .wout file, varying from run to
run and from build to build, and made testw90_na_chain_gamma fail
intermittently, since the test reads the output file as text (this showed at
least twice in the Fedora/gcc test - pinging @JeromeCCP9 who saw this).

The variable is now set to "none" by default, which is the value the report was
always meant to show. The width of the field is unchanged, so all existing
output is byte-identical.

The pull request also adds a CI step that saves the test working directory when
a job fails, so output files from an intermittent failure can be inspected
afterwards. It also corrects the description of the `na_chain_gamma` test, which named
the wrong material.