### PR TITLE
Print the M_orb summary in berry.F90 with f16.10 instead of f10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### More digits in the `M_orb` summary printed by `postw90.x`
+
+The `berry_task = morb` summary is printed with `f16.10` instead of `f10.4`; in bohr
+magneton/cell these values are often 1e-3 or smaller, so four decimals showed almost no
+significant digits. Test tolerances for `morb_x/y/z` become `{abs: 1.0e-4, rel: null}`,
+since the components that are zero by symmetry now print their cancellation residual and a
+relative check against a zero reference is undefined.
+
 ### `wannier90.x`, `postw90.x` and the utilities now exit nonzero on a fatal error
 
 Previously a fatal error ended in a bare Fortran `stop`, which exits with status **0**. A

--- a/src/postw90/berry.F90
+++ b/src/postw90/berry.F90
@@ -1477,20 +1477,20 @@ contains
           if (print_output%iprint > 1) then
             write (stdout, '(1x,a)') &
               '======================'
-            write (stdout, '(1x,a22,2x,3(f10.4,1x))') 'Local circulation :', &
+            write (stdout, '(1x,a22,2x,3(f16.10,1x))') 'Local circulation :', &
               sum(LCtil_list(1:3, 1, if)), sum(LCtil_list(1:3, 2, if)), &
               sum(LCtil_list(1:3, 3, if))
-            write (stdout, '(1x,a22,2x,3(f10.4,1x))') &
+            write (stdout, '(1x,a22,2x,3(f16.10,1x))') &
               'Itinerant circulation:', &
               sum(ICtil_list(1:3, 1, if)), sum(ICtil_list(1:3, 2, if)), &
               sum(ICtil_list(1:3, 3, if))
             write (stdout, '(1x,a)') &
               '--------------------------------------------------------'
-            write (stdout, '(1x,a22,2x,3(f10.4,1x),/)') 'Total   :', &
+            write (stdout, '(1x,a22,2x,3(f16.10,1x),/)') 'Total   :', &
               sum(Morb_list(1:3, 1, if)), sum(Morb_list(1:3, 2, if)), &
               sum(Morb_list(1:3, 3, if))
           else
-            write (stdout, '(1x,a22,2x,3(f10.4,1x),/)') &
+            write (stdout, '(1x,a22,2x,3(f16.10,1x),/)') &
               '======================', &
               sum(Morb_list(1:3, 1, if)), sum(Morb_list(1:3, 2, if)), &
               sum(Morb_list(1:3, 3, if))

--- a/test-suite/profiles.yaml
+++ b/test-suite/profiles.yaml
@@ -159,9 +159,9 @@ postw90_wpout:
     ahc_x: {abs: 0.001, rel: 0.002}
     ahc_y: {abs: 0.001, rel: 0.002}
     ahc_z: {abs: 0.001, rel: 0.002}
-    morb_x: {abs: 0.001, rel: 0.002}
-    morb_y: {abs: 0.001, rel: 0.002}
-    morb_z: {abs: 0.001, rel: 0.002}
+    morb_x: {abs: 1.0e-4, rel: null}
+    morb_y: {abs: 1.0e-4, rel: null}
+    morb_z: {abs: 1.0e-4, rel: null}
     spin_x: {abs: 0.001, rel: 0.002}
     spin_y: {abs: 0.001, rel: 0.002}
     spin_z: {abs: 0.001, rel: 0.002}


### PR DESCRIPTION
## Problem
The `M_orb` summary written by `berry_task = morb` printed local circulation, itinerant
circulation and total with `f10.4` — four decimals. In bohr magneton/cell these are routinely
of order 1e-3 or smaller, so the `.wout` carried almost no significant digits and k-mesh
convergence could not be judged from it. For the Fe tests the printed total was

```
 M_orb (bohr magn/cell)        x          y          z
 ======================      0.0000     0.0000     0.0431
```

## Fix
`src/postw90/berry.F90` — `f10.4` → `f16.10` at the four write statements of the summary:

```
 ======================      0.0000013144     0.0000002854     0.0430559492
```

Both edit descriptors give the integer part the same five characters, so nothing that fitted
in `f10.4` overflows in `f16.10`, and `parse_wpout.py` matches the values with a
whitespace-tolerant regex.

`test-suite/profiles.yaml` — `morb_x/y/z` become `{abs: 1.0e-4, rel: null}`:

- `morb_x` and `morb_y` are zero by symmetry in the Fe tests. The benchmarks record them as
  `0.0000` because `f10.4` rounded the cancellation residual away; printing the residual makes
  the relative check divide by a zero reference (`rel err inf`).
- `gyro_x/y/z` and `shc` already use `rel: null` for the same reason.
- The residuals are not reproducible quantities anyway: `morb` and its translationally-invariant
  variant disagree on them by 17% (1.31e-6 vs 1.54e-6).
- The new absolute limit matches the old *effective* one, which was set by `rel: 0.002` on
  `morb_z ≈ 0.0431`, i.e. ~8.6e-5.

No benchmark regeneration: the printed values are unchanged, only their field width.

## Test
Full suite: **189 passed, 1 skipped** (the skip needs `--nprocs>=2`), including all 7 morb
tests. Without the `profiles.yaml` change the same 7 give 4 failures, all of the form

```
morb_x[0]: test=1.543e-06 benchmark=-0.0
    abs err 1.543000e-06 (limit 1.000e-03); rel err inf (limit 2.000e-03)
```

i.e. absolute error three orders inside tolerance, relative error undefined against a zero
reference.
